### PR TITLE
asciibinder.css needs to include the font-awesome.min css from CDN.

### DIFF
--- a/_stylesheets/asciibinder.css
+++ b/_stylesheets/asciibinder.css
@@ -1,3 +1,4 @@
+@import url(http://maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css);
 /* ------------------------------------------------------------
 Image: "Spin" https://www.flickr.com/photos/eflon/3655695161/
 Author: eflon https://www.flickr.com/photos/eflon/


### PR DESCRIPTION

We're missing icons in the rendered doc, was missing the font awesome css.
