### PR TITLE
Update API examples after Provider types have changed

### DIFF
--- a/api/examples/create_provider.adoc
+++ b/api/examples/create_provider.adoc
@@ -11,7 +11,7 @@ POST /api/providers
 [source,json]
 ----
 {
-  "type"      : "EmsRedhat",
+  "type"      : "ManageIQ::Providers::Redhat::InfraManager",
   "name"      : "rhevm101",
   "hostname"  : "rhevm101",
   "ipaddress" : "100.200.300.101",
@@ -37,7 +37,7 @@ POST /api/providers
       "updated_on": "2015-05-05T15:47:41Z",
       "guid": "10360312-f33e-11e4-86c7-b8e85646e742",
       "zone_id": 1,
-      "type": "EmsRedhat"
+      "type": "ManageIQ::Providers::Redhat::InfraManager"
     }
   ]
 }

--- a/api/examples/create_provider_compound_credentials.adoc
+++ b/api/examples/create_provider_compound_credentials.adoc
@@ -11,7 +11,7 @@ POST /api/providers
 [source,json]
 ----
 {
-  "type"      : "EmsRedhat",
+  "type"      : "ManageIQ::Providers::Redhat::InfraManager",
   "name"      : "rhevm102",
   "hostname"  : "rhevm102",
   "ipaddress" : "100.200.300.102",
@@ -44,7 +44,7 @@ POST /api/providers
       "updated_on": "2015-05-05T15:57:44Z",
       "guid": "acbd610e-f3f6-11e4-aaba-b8e85646e742",
       "zone_id": 1,
-      "type": "EmsRedhat"
+      "type": "ManageIQ::Providers::Redhat::InfraManager"
     }
   ]
 }

--- a/api/examples/update_provider.adoc
+++ b/api/examples/update_provider.adoc
@@ -37,7 +37,7 @@ POST /api/providers/106
   "updated_on": "2015-05-06T13:53:06Z",
   "guid": "acbd610e-f3f6-11e4-aaba-b8e85646e742",
   "zone_id": 1,
-  "type": "EmsRedhat"
+  "type": "ManageIQ::Providers::Redhat::InfraManager"
 }
 ----
 

--- a/api/overview/crud.adoc
+++ b/api/overview/crud.adoc
@@ -44,7 +44,7 @@ Create a new provider: *POST /api/providers*
 curl --user admin:smartvm
       -i -X POST -H "Accept: application/json"
       -d '{
-            "type"      : "EmsRedhat",
+            "type"      : "ManageIQ::Providers::Redhat::InfraManager",
             "name"      : "RHEVM Provider",
             "hostname"  : "rhevm.local.com",
             "ipaddress" : "192.168.5.1",


### PR DESCRIPTION
The rename happened during v2.0/v2.1 transition. At this point we
perhaps want to have the examples using the latest greatest to avoid
user surprises.