### PR TITLE
[auth] Fixes in the SAML setup instruction documentation

### DIFF
--- a/auth/saml.adoc
+++ b/auth/saml.adoc
@@ -45,9 +45,9 @@ Copy the Apache remote user and SAML template configuration files:
 
 ```
 # TEMPLATE_DIR="/var/www/miq/system/TEMPLATE"
-# cp ${TEMPLATE_DIR}/etc/http/conf.d/manageiq-remote-user.conf        \
+# cp ${TEMPLATE_DIR}/etc/httpd/conf.d/manageiq-remote-user.conf        \
     /etc/httpd/conf.d/
-# cp ${TEMPLATE_DIR}/etc/http/conf.d/manageiq-external-auth-saml.conf \
+# cp ${TEMPLATE_DIR}/etc/httpd/conf.d/manageiq-external-auth-saml.conf \
     /etc/httpd/conf.d/
 ```
 
@@ -75,7 +75,7 @@ the mod_auth_mellon command _mellon_create_metadata.sh_ as follows:
 
 ```
 # cd /etc/httpd/saml2
-# mellon_create_metadata.sh https://<miq-appliance> https://<miq-appliance>/saml2
+# /usr/libexec/mod_auth_mellon/mellon_create_metadata.sh https://<miq-appliance> https://<miq-appliance>/saml2
 ```
 
 The mellon_create_metadata.sh script creates file names based on the appliance URL but
@@ -131,6 +131,12 @@ mod_auth_mellon and KeyCloak:
 >   Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
     Location=
   ...
+```
+
+Finally, restart Apache on the appliance as follows:
+
+```
+# systemctl restart httpd
 ```
 
 [[saml-assertions]]


### PR DESCRIPTION
- wrong path specified for Apache template files
- needed the full path for mellon_create_metadata.sh
- needed an Apache restart step