### PR TITLE
update installing_cloudforms_on_vmware_vsphere downstream references

### DIFF
--- a/installing_cloudforms_on_vmware_vsphere/additional_configuration.adoc
+++ b/installing_cloudforms_on_vmware_vsphere/additional_configuration.adoc
@@ -1,0 +1,52 @@
+[[additional-requirements]]
+== Additional Requirements
+
+=== Installing VMware VDDK on {product-title}
+
+Execution of SmartState Analysis on virtual machines within a VMware environment requires the Virtual Disk Development Kit (VDDK). {product-title} supports VDDK 5.5.
+
+. Download `VDDK 5.5` (`VMware-vix-disklib-5.5.0-1284542.x86_64.tar.gz` at the time of this writing) from the VMware website.
++
+[NOTE]
+=======
+If you do not already have a login ID to VMware, then you will need to create one. At the time of this writing, the file can be found by navigating to menu:Downloads[All Downloads, Drivers & Tools]. Select menu:VMware vSphere[Drivers & Tools]. Expand *Automation Tools and SDKs*, and select *vSphere Virtual Disk Development Kit 5.5*. Alternatively, find the file by searching for it using the *Search* on the VMware site.
+=======
++
+. Download and copy the `VMware-vix-disklib-5.5.0-1284542.x86_64.tar.gz` file to the `/root` directory of the appliance.
+. Start an SSH session into the appliance.
+. Extract and install `VDDK 5.5` using the following commands:
+
++
+----
+# cd /root
+# tar -xvf VMware-vix-disklib-5.5.0-1284542.x86_64.tar.gz
+# cd vmware-vix-disklib-distrib
+# /vmware-install.pl
+----
++
+. Accept the defaults during the installation:
++
+----
+Installing VMware VIX DiskLib API. You must read and accept the VMware VIX DiskLib API End User License Agreement to continue. Press enter to display it. Do you accept? (yes/no) yes
+
+Thank you. What prefix do you want to use to install VMware VIX DiskLib API? The prefix is the root directory where the other folders such as man, bin, doc, lib, etc. will be placed. [/usr] (Press Enter)
+
+The installation of VMware VIX DiskLib API 5.5.0 build-1284542 for Linux completed successfully. You can decide to remove this software from your system at any time by invoking the following command:
+"/usr/bin/vmware-uninstall-vix-disklib.pl". Enjoy, --the VMware team
+----
++
+. Run `ldconfig` to instruct {product-title} to find the newly installed VDDK library.
+
++
+[NOTE]
+======
+Use the following command to verify the VDDK files are listed and accessible to the appliance:
+----
+# ldconfig -p | grep vix
+----
+======
++
+
+. Restart the {product-title} appliance.
+
+The VDDK is now installed on the {product-title} appliance. This enables use of the SmartState Analysis Server Role on the appliance.

--- a/installing_cloudforms_on_vmware_vsphere/configuring_cloudforms.adoc
+++ b/installing_cloudforms_on_vmware_vsphere/configuring_cloudforms.adoc
@@ -1,0 +1,156 @@
+[[Configuring-{product-title}]]
+== Configuring {product-title}
+
+Although the {product-title} Appliance comes configured to be integrated immediately into your environment, you can make some changes to its configuration.
+
+[NOTE]
+======
+The {product-title} Appliance is intended to have minimal configuration options.
+======
+
+=== Changing Configuration Settings
+
+The procedure describes how to make changes to the configuration settings on the {product-title} appliance.
+
+. After starting the appliance, log in with a user name of `root` and the default password of `smartvm`. This displays the Bash prompt for the `root` user.
+. Enter the `appliance_console` command. The {product-title} Appliance summary screen displays.
+. Press `Enter` to manually configure settings.
+. Press the number for the item you want to change, and press `Enter`. The options for your selection are displayed.
+. Follow the prompts to make the changes.
+. Press `Enter` to accept a setting where applicable.
+
+[NOTE]
+======
+The {product-title} Appliance console automatically logs out after five minutes of inactivity.
+======
+
+=== Advanced Configuration Settings
+
+After logging in, you can use the following menu items for advanced configuration of the appliance:
+
+* Use *Set DHCP Network Configuration* to use DHCP to obtain the IP address and network configuration for your {product-title} Appliance. The appliance is initially configured as a DHCP client with bridged networking.
+* Use *Set Static Network Configuration* if you have a specific IP address and network settings you need to use for the {product-title} Appliance.
+* Use *Test Network Configuration* to check that name resolution is working correctly.
+* Use *Set Hostname* to specify a hostname for the {product-title} Appliance.
++
+[IMPORTANT]
+======
+A valid fully qualified hostname for the {product-title} appliance is required for SmartState analysis to work correctly,
+======
++
+* Use *Set Timezone, Date, and Time* to configure the time zone, date, and time for the {product-title} Appliance.
+* Use *Restore Database from Backup* to restore the VMDB database from a previous backup.
+* Use *Setup Database Region* to create regions for VMDB replication.
+* Use *Configure Database* to configure the VMDB database. Use this option to configure the database for the appliance after installing and running it for the first time.
+* Use *Extend Temporary Storage* to add temporary storage to the appliance. The appliance formats an unpartitioned disk attached to the appliance host and mounts it at `/var/www/miq_tmp`. The appliance uses this temporary storage directory to perform certain image download functions.
+* Use *Configure External Authentication (httpd)* to configure authentication through an IPA server.
+* Use *Generate Custom Encryption Key* to regenerate the encryption key used to encode plain text password.
+* Use *Harden Appliance Using SCAP Configuration* to apply Security Content Automation Protocol (SCAP) standards to the appliance. You can view these SCAP rules in the `/var/www/miq/lib/appliance_console/config/scap_rules.yml` file.
+* Use *Stop Server Processes* to stop all server processes. You may need to do this to perform maintenance.
+* Use *Start Server Processes* to start the server. You may need to do this after performing maintenance.
+* Use *Restart Appliance* to restart the {product-title} Appliance. You can either restart the appliance and clear the logs or just restart the appliance.
+* Use *Shut Down Appliance* to power down the appliance and exit all processes.
+* Use *Summary Information* to go back to the network summary screen for the {product-title} Appliance.
+* Use *Quit* to leave the {product-title} Appliance console.
+
+[[configuring_a_database]]
+=== Configuring a Database for {product-title}
+
+Before using {product-title}, configure the database options for it. {product-title} provides two options for database configuration:
+
+* Install an internal PostgreSQL database to the appliance
+* Configure the appliance to use an external PostgreSQL database
+
+[NOTE]
+=======
+See link:https://access.redhat.com/documentation/en/red-hat-cloudforms/version-4.1-beta/deployment-planning-guide/#cpu_sizing_assistant_for_a_dedicated_vmdb_host[CPU Sizing Assistant for a Dedicated VMDB Host] in the Deployment Planning Guide for guidelines on CPU requirements.
+=======
+
+
+=== Configuring an Internal Database
+
+[IMPORTANT]
+======
+Before installing an internal database, add a disk to the infrastructure hosting your appliance. See the documentation specific to your infrastructure for instructions on how to add a disk. As a storage disk usually cannot be added while a virtual machine is running, it is recommend adding the disk before starting the appliance. {product-title} only supports installing of an internal VMDB on blank disks. The installation will fail if the disks are not blank.
+======
+
+. Start the appliance and open a terminal from your virtualization or cloud provider.
+. After starting the appliance, log in with a user name of `root` and the default password of `smartvm`. This displays the Bash prompt for the `root` user.
+. Enter the `appliance_console` command. The {product-title} Appliance summary screen displays.
+. Press *Enter* to manually configure settings.
+. Select *8) Configure Database* from the menu.
+. You are prompted to create or fetch an encryption key.
+* If this is the first {product-title} appliance, choose *1) Create key*.
+* If this is not the first {product-title} appliance, choose *2) Fetch key* from remote machine to fetch the key from the first {product-title} appliance. All {product-title} appliances in a multi-region deployment must use the same key.
+. Choose *1) Internal* for the database location.
+. Choose a disk for the database. For example:
++
+----
+1)  /dev/vdb: 20480
+
+Choose disk:
+----
++
+Enter *1* to choose `/dev/vdb` for the database location.
+
+. When prompted, enter a unique three digit region ID to create a new region.
++
+[IMPORTANT]
+======
+Creating a new region destroys any existing data on the chosen database.
+======
++
+.  Confirm the configuration when prompted.
+
+{product-title} configures the internal database.
+
+=== Configuring an External Database
+
+The `postgresql.conf` file used with {product-title} databases requires specific settings for correct operation. For example, it must correctly reclaim table space, control session timeouts, and format the PostgreSQL server log for improved system support. Due to these requirements, it is recommend that external {product-title} databases use a `postgresql.conf` file based on the standard file used by the {product-title} appliance.
+
+Ensure you configure the settings in the `postgresql.conf` to suit your system. For example, customize the `shared_buffers` setting according to the amount of real storage available in the external system hosting the PostgreSQL instance. In addition, depending on the aggregate number of appliances expected to connect to the PostgreSQL instance, it may be
+necessary to alter the `max_connections` setting.
+
+Because the `postgresql.conf` file controls the operation of all databases managed by a single instance of PostgreSQL, do not mix {product-title} databases with other types of databases in a single PostgreSQL instance.
+
+[NOTE]
+======
+{product-title} requires PostgreSQL version 9.4.
+======
+
+. Start the appliance and open a terminal console from your virtualization or cloud provider.
+. After starting the appliance, log in with a user name of `root` and the default password of `smartvm`. This displays the Bash prompt for the `root` user.
+. Enter the `appliance_console` command. The {product-title} Appliance summary screen displays.
+. Press *Enter* to manually configure settings.
+. Select *8) Configure Database* from the menu.
+. You are prompted to create or fetch a security key.
+* If this is the first {product-title} appliance, select the option to create a key.
+* If this is not the first {product-title} appliance, select the option to fetch the key from the first {product-title} appliance. All {product-title} appliances in a multi-region deployment must use the same key.
+. Choose *2) External* for the database location.
+. Enter the database hostname or IP address when prompted.
+. Enter the database name or leave blank for the default (`vmdb_production`).
+. Enter the database username or leave blank for the default (`root`).
+. Enter the chosen database user's password.
+. Confirm the configuration if prompted.
+
+{product-title} will then configure the external database.
+
+=== Configuring a Worker Appliance for {product-title}
+
+You can configure a worker appliance through the terminal. These steps demonstrate how to join a worker appliance to an appliance that already has a region configured with a database.
+
+. Start the appliance and open a terminal from your virtualization or cloud provider.
+. After starting the appliance, log in with a user name of `root` and the default password of `smartvm`. This displays the Bash prompt for the `root` user.
+. Enter the `appliance_console` command. The {product-title} Appliance summary screen displays.
+. Press *Enter* to manually configure settings.
+. Select *8) Configure Database* from the menu.
+. You are prompted to create or fetch a security key. Select the option to fetch the key from the first {product-title} appliance. All {product-title} appliances in a multi-region deployment must use the same key.
+. Choose *2) External* for the database location.
+. Enter the database hostname or IP address when prompted.
+. Enter the database name or leave blank for the default (`vmdb_production`).
+. Enter the database username or leave blank for the default (`root`).
+. Enter the chosen database user's password.
+. Confirm the configuration if prompted.
+
+
+

--- a/installing_cloudforms_on_vmware_vsphere/docinfo.xml
+++ b/installing_cloudforms_on_vmware_vsphere/docinfo.xml
@@ -1,0 +1,8 @@
+<title>Installing {product-title} on VMware vSphere</title>
+<productname>{product-title}</productname>
+<productnumber>-Beta</productnumber>
+<subtitle>How to Install and Configure the C{product-title} Appliance on a VMware vSphere environment</subtitle>
+<abstract>
+    <para>This guide provides installation and configuration instructions for the {product-title} Appliance. Information and procedures in this book are relevant to {product-title} administrators.</para>
+</abstract>
+

--- a/installing_cloudforms_on_vmware_vsphere/installing_cloudforms.adoc
+++ b/installing_cloudforms_on_vmware_vsphere/installing_cloudforms.adoc
@@ -1,0 +1,52 @@
+[[installing-{product-title}]]
+== Installing {product-title}
+
+{product-title} is able to be installed and ready to configure in a few quick steps. After downloading {product-title} as a virtual machine image template from the Red Hat Customer Portal, the installation process takes you through the steps of uploading the appliance to a supported virtualization or cloud provider.
+
+[IMPORTANT]
+======
+After installing the {product-title} Appliance, you must configure the database for {product-title}. See xref:configuring_a_database[].
+======
+
+=== Obtaining the {product-title} Appliance
+
+. Go to link:https://access.redhat.com[access.redhat.com] and log in to the Red Hat Customer Portal using your customer account details.
+. Click *Downloads* in the menu bar.
+. Click *A-Z* to sort the product downloads alphabetically.
+. Click menu:{product-title} [Download Latest] to access the product download page.
+. From the list of installers and images, select the *{product-title} VMware Virtual Appliance* download link.
+
+=== Uploading the Appliance on VMware vSphere
+
+Uploading the {product-title} Appliance file onto VMware vSphere systems has the following requirements:
+
+* 44 GB of space on the chosen vSphere datastore.
+* Administrator access to the vSphere Client.
+* Depending on your infrastructure, allow time for the upload.
+
+[NOTE]
+======
+These are the procedural steps as of the time of writing. For more information, consult the VMware documentation.
+======
+
+Use the following procedure to upload the {product-title} Appliance OVF template from your local file system using the vSphere Client.
+
+. In the vSphere Client, select menu:File[Deploy OVF Template]. The Deploy OVF Template wizard appears.
+. Specify the source location and click *Next*.
+* Select *Deploy from File* to browse your file system for the OVF template, for example `{product-title}-vsphere-5.4-43.x86_64.vsphere.ova`.
+* Select *Deploy from URL* to specify a URL to an OVF template located on the internet.
+. View the *OVF Template Details* page and click *Next*.
+. Select the deployment configuration from the drop-down menu and click *Next*. The option selected typically controls the memory settings, number of CPUs and reservations, and application-level configuration parameters.
+. Select the host or cluster on which you want to deploy the OVF template and click *Next*.
+. Select the host on which you want to run the run the {product-title} appliance, and click *Next*.
+. Navigate to, and select the resource pool where you want to run the {product-title} appliance and click *Next*.
+. Select a datastore to store the deployed {product-title} Appliance, and click Next. Ensure to select a datastore large enough to accommodate the virtual machine and all of its virtual disk files.
+. Select the disk format to store the virtual machine virtual disks, and click *Next*.
+* Select *Thin Provisioned* if the storage is allocated on demand as data is written to the virtual disks.
+* Select *Thick Provisioned* if all storage is immediately allocated.
+. For each network specified in the OVF template, select a network by right-clicking the *Destination Network* column in your infrastructure to set up the network mapping and click *Next*.
+. The *IP Allocation* page does not require any configuration changes. Leave the default settings in the *IP Allocation* page and click *Next*.
+. Set the user-configurable properties and click *Next*. The properties to enter depend on the selected IP allocation scheme. For example, you are prompted for IP related information for the deployed virtual machines only in the case of a fixed IP allocation scheme.
+. Review your settings and click *Finish*.
+
+The progress of the import task appears in the vSphere Client Status panel.

--- a/installing_cloudforms_on_vmware_vsphere/master.adoc
+++ b/installing_cloudforms_on_vmware_vsphere/master.adoc
@@ -1,0 +1,15 @@
+= Installing {product-title} on VMware vSphere
+{product-title} Documentation Team <cloudforms-docs@redhat.com>
+:imagesdir: images
+:vernum: 
+:toc: left
+:toclevels: 3
+:experimental:
+:numbered!:
+:compat-mode:
+
+:numbered:
+include::Installing_CloudForms.adoc[]
+include::Configuring_CloudForms.adoc[]
+include::Additional_Configuration.adoc[]
+

--- a/installing_cloudforms_on_vmware_vsphere/metadata.ini
+++ b/installing_cloudforms_on_vmware_vsphere/metadata.ini
@@ -1,0 +1,20 @@
+[source]
+language = en-US
+type = book
+markup = docbook
+
+[metadata]
+title = Installing {product-title} on VMware vSphere
+product = {product-title}
+version = 
+edition = 
+subtitle = 
+keywords = 
+abstract = 
+
+[bugs]
+reporting_url = 
+type = 
+product = 
+component = Documentation
+


### PR DESCRIPTION
Default operations performed over all Pull Request of this team
-Downcased names of files
-Changed 'Red Hat CloudForms', 'CloudForms' ,'Cloudforms' ,'Cloudforms Management Engine' ,'CFME' with {product-title} 
-Changed '4.0' with {product-version} 
-Removed references to  '4.x' ,'3.x' ,'3.1' ,'3.2'

Specific commentaries of this PR:

Theses changes were originally made by @CarlosGlez7, his comments were:



Changed "Red Hat" for: “it is recommend” in the file: Installing_CloudForms_on_Vmware_vSphere/Installing_CloudForms.adoc

I didn't change the phrase: “Red Hat Customer Portal” on lines 4 and 13 in the file:
Installing_CloudForms_on_Vmware_vSphere/docinfo.xml


@katafira @delaluzparra @sergio-ocon