### PR TITLE
Add Quick Setup steps to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Alternately, if you want to "live edit" the docs, replace the last two steps wit
 For questions or comments about the documentation system, try one of the following:
 
 * The [manageiq_docs](https://gitter.im/ManageIQ/manageiq_docs) channel on [Gitter](https://gitter.im).
-* The [#manageiq](http://manageiq.org/community/irc/) IRC channel on [FreeNode](http://www.freenode.net/).
 * The [talk.manageiq.org](http://talk.manageiq.org) forum.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -11,6 +11,23 @@ This repo contains the documentation for
 
 The documentation in this repository is built and deployed using [AsciiBinder](http://asciibinder.org).  If you're new to AsciiBinder, head over there and read up on how to contribute documentation.
 
+### Quick setup
+
+* Be sure to have a Ruby installed with the bundler gem (if you don't have bundler, just run `gem install bundler`)
+* Clone the manageiq_docs repo.
+* `cd` into the new manageiq_docs repo directory.
+* `bundle install`
+* `bundle exec ascii_binder` - This will build the documentation into the _preview directory
+* `open _preview/manageiq/master/welcome/index.html`
+
+Alternately, if you want to "live edit" the docs, replace the last two steps with:
+
+* Install the LiveReload browser extension: http://livereload.com/extensions/
+* `bundle exec ascii_binder watch`
+* `open _preview/manageiq/master/welcome/index.html`
+* Go to the open page in the browser and enable the LiveReload extension for that page.
+* Edit the docs.  When you save, it will auto-build and then the webpage will reload automatically showing your changes.
+
 ## Contacts
 
 For questions or comments about the documentation system, try one of the following:


### PR DESCRIPTION
This expands on the section where it says "go read about AsciiBinder" to have more explicit helper steps for those new to the project.

@chessbyte @mfeifer Please review.