### PR TITLE
Add build as tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+rvm:
+- "2.2.5"
+sudo: false
+cache: bundler

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ManageIQ Documentation
 
+[![Build Status](https://travis-ci.org/ManageIQ/manageiq_docs.svg?branch=master)](https://travis-ci.org/ManageIQ/manageiq_docs)
 [![Gitter](https://badges.gitter.im/ManageIQ/manageiq_docs.svg)](https://gitter.im/ManageIQ/manageiq_docs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 This repo contains the documentation for

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+desc "Run tests by executing the ascii_binder build"
+task :test do
+  exec("bundle exec ascii_binder build --distro manageiq")
+end
+
+task :default => :test


### PR DESCRIPTION
This PR adds a rake task for testing that just builds the docs and ensures it succeeds.  We can eventually expand on this if needed.  This PR also adds Travis support to run this on every new PR.
