### PR TITLE
Updated .gitignore with global ignores for downstream build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+## Global ignores
+
+*/build/*
+*/cfme/build/*
+*/miq/build/*
+*/publish/*
+*/tmp/*
+*.swp
+
 ## AsciiBinder-specific ignores
 _preview
 _package


### PR DESCRIPTION
This update allows build directories created by tools other than AsciiBinder to be ignored.