### PR TITLE
BZ#1334812: Scheduling OpenScap Compliance Check (added step)

### DIFF
--- a/doc-Policies_and_Profiles_Guide/topics/OpenSCAP_Integration.adoc
+++ b/doc-Policies_and_Profiles_Guide/topics/OpenSCAP_Integration.adoc
@@ -30,17 +30,7 @@ The OpenSCAP policy profile included with {product-title} is not automatically a
 
 Once you have assigned the built-in OpenSCAP policy profile to a container provider, you can schedule a compliance check against the policy profile. The method for doing is similar to that of scheduling a normal compliance check (xref:compliance-schedule[]):
 
-. Click the *Settings* accordion, and select *Schedules*.
-
-. Click image:../images/1847.png[image] (*Configuration*),
-image:../images/1862.png[image] (*Add a new Schedule*).
-
-. In the *Adding a new Schedule* area, type in a name and description for the
-schedule.
-+
-image:../images/1940.png[image]
-
-. Check *Active* to enable the scan.
+include::steps_schedule-compliance-check.adoc[]
 
 . From the *Action* dropdown, select *Container Image Analysis*.
 

--- a/doc-Policies_and_Profiles_Guide/topics/To_schedule_a_Compliance_check.adoc
+++ b/doc-Policies_and_Profiles_Guide/topics/To_schedule_a_Compliance_check.adoc
@@ -1,19 +1,7 @@
 [[compliance-schedule]]
 ===== Scheduling a Compliance Check
 
-. Navigate to menu:Settings[Configuration].
-
-. Click the *Settings* accordion, and select *Schedules*.
-
-. Click image:../images/1847.png[image] (*Configuration*),
-image:../images/1862.png[image] (*Add a new Schedule*).
-
-. In the *Adding a new Schedule* area, type in a name and description for the
-schedule.
-+
-image:../images/1940.png[image]
-
-. Check *Active* if you want to enable this scan.
+include::steps_schedule-compliance-check.adoc[]
 
 . From the *Action* dropdown, select the type of compliance check you want to schedule. Depending on the type of analysis you choose, you are presented with one of the following group boxes:
 

--- a/doc-Policies_and_Profiles_Guide/topics/steps_schedule-compliance-check.adoc
+++ b/doc-Policies_and_Profiles_Guide/topics/steps_schedule-compliance-check.adoc
@@ -1,0 +1,13 @@
+. Navigate to menu:Settings[Configuration].
+
+. Click the *Settings* accordion, and select *Schedules*.
+
+. Click image:../images/1847.png[image] (*Configuration*),
+image:../images/1862.png[image] (*Add a new Schedule*).
+
+. In the *Adding a new Schedule* area, type in a name and description for the
+schedule.
++
+image:../images/1940.png[image]
+
+. Check *Active* if you want to enable this scan.


### PR DESCRIPTION
The procedure for scheduling an OpenSCAP compliance check on
container images was missing a step. This commit adds that step
and single-sources the first few steps of that procedure with the
more general 'Scheduling a compliance check'.