### PR TITLE
fixed winrm quickconfig command

### DIFF
--- a/doc-Managing_Providers/topics/Authenticating_to_Microsoft_SCVMM.adoc
+++ b/doc-Managing_Providers/topics/Authenticating_to_Microsoft_SCVMM.adoc
@@ -6,7 +6,7 @@ Before you can add a Microsoft SCVMM provide to your {product-title} environment
 . Enable WinRM for configuration.
 +
 ----
-winrm quick config
+winrm quickconfig
 ----			
 +
 . Set the following options:  


### PR DESCRIPTION
From bug: "In section 1.5.1 the command to Enable WinRM for configuration. is "winrm quickconfig" instead of "winrm quick config". "  

@suyogsainkar, would you mind merging this please?  
Thanks so much!