### PR TITLE
Added 'providing feedback' paragraph to abstract of all docs

### DIFF
--- a/art-Assigning_Custom_Analysis_Profile_to_VM/cfme/docinfo.xml
+++ b/art-Assigning_Custom_Analysis_Profile_to_VM/cfme/docinfo.xml
@@ -4,5 +4,6 @@
 <subtitle>How to assign a custom CloudForms analysis profile to a virtual machine</subtitle>
 <abstract>
     <para>This guide provides instructions for assigning a custom CloudForms analyis profile to a virtual machine.</para>
+    <para>If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis> for the <emphasis role="strong">Documentation</emphasis> component. Please provide specific details, such as the section number, guide name, and CloudForms version so we can easily locate the content.</para>
 </abstract>
 

--- a/doc-Appliance_Hardening_Guide/cfme/docinfo.xml
+++ b/doc-Appliance_Hardening_Guide/cfme/docinfo.xml
@@ -4,6 +4,7 @@
 <subtitle>Instructions on enhancing the security of your Red Hat CloudForms appliances</subtitle>
 <abstract>
    <para>This guide provides a few procedures to help enhance security to your CloudForms appliances. This includes customizing passwords, restricting unnecessary communication, and encryption key and certificate generation.</para>
+   <para>If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis> for the <emphasis role="strong">Documentation</emphasis> component. Please provide specific details, such as the section number, guide name, and CloudForms version so we can easily locate the content.</para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/doc-Deployment_Planning_Guide/cfme/docinfo.xml
+++ b/doc-Deployment_Planning_Guide/cfme/docinfo.xml
@@ -4,6 +4,7 @@
 <subtitle>Planning for the deployment of Red Hat CloudForms</subtitle>
 <abstract>
     <para>This guide provides guidance on planning for the deployment of Red Hat CloudForms to suit your cloud environment.</para>
+    <para>If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis> for the <emphasis role="strong">Documentation</emphasis> component. Please provide specific details, such as the section number, guide name, and CloudForms version so we can easily locate the content.</para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/doc-Deployment_Planning_Guide/topics/introduction.adoc
+++ b/doc-Deployment_Planning_Guide/topics/introduction.adoc
@@ -49,7 +49,7 @@ Red Hat recommends allocating the virtual machine disk fully at the time of crea
 * Host Count: the number of hosts associated with the provider.
 * Storage Count: the number of individual storage elements as seen from the perspective of the provider or host. It is not the total number of virtual disks for all virtual machines.
 
-Use the following table as a guideline to calculate minimum requirements for your dataebase:
+Use the following table as a guideline to calculate minimum requirements for your database:
 
 image:5780.png[]
 

--- a/doc-Deployment_Planning_Guide/topics/introduction.adoc
+++ b/doc-Deployment_Planning_Guide/topics/introduction.adoc
@@ -30,7 +30,34 @@ A SmartProxy agent must configured in each storage location, and must be visible
 
 === Requirements
 
-To use {product-title}, the following requirements must be met:
+//Write intro.
+To use {product-title}, certain hardware, browser, and database requirements must be met in your environment. 
+
+
+==== Hardware Requirements
+
+The {product-title} appliance requires the following hardware at minimum:
+
+* 4 VCPUs
+* 8 GB RAM
+* 44 GB HDD + optional database disk
+
+==== Database Requirements
+
+Red Hat recommends allocating the virtual machine disk fully at the time of creation. Three main factors affect the size of your database over time:
+
+* Virtual Machine Count: the most important factor in the calculation of virtual machine database (VMDB) size over time.
+* Host Count: the number of hosts associated with the provider.
+* Storage Count: the number of individual storage elements as seen from the perspective of the provider or host. It is not the total number of virtual disks for all virtual machines.
+
+Use the following table as a guideline to calculate minimum requirements for your dataebase:
+
+image:5780.png[]
+
+
+==== Browser Requirements
+
+To use {product-title}, the following browser requirements must be met:
 
 * One of the following web browsers:
 ** Mozilla Firefox for versions supported under Mozilla's Extended Support Release (ESR)
@@ -38,14 +65,21 @@ To use {product-title}, the following requirements must be met:
 ** Google Chrome for Business
 * A monitor with minimum resolution of 1280x1024.
 * Adobe Flash Player 9 or above. At the time of publication, you can access it at http://www.adobe.com/products/flashplayer/
-* The {product-title} appliance must already be installed and activated in your enterprise environment.
-* The SmartProxy must have visibility to the virtual machines and cloud instances that you want to control.
-* The resources that you want to control must have a SmartProxy associated with them.
+
 
 [IMPORTANT]
 ======
 Due to browser limitations, Red Hat supports logging in to only one tab for each multi-tabbed browser. Console settings are saved for the active tab only. For the same reason, {product-title} does not guarantee that the browser's *Back* button will produce the desired results. Red Hat recommends using the breadcrumbs provided in the Console.
 ======
+
+==== Additional Requirements
+
+Additionally, the following must be configured to use {product-title}:
+
+* The {product-title} appliance must already be installed and activated in your enterprise environment.
+* The SmartProxy must have visibility to the virtual machines and cloud instances that you want to control.
+* The resources that you want to control must have a SmartProxy associated with them.
+
 
 === Terminology
 

--- a/doc-Deployment_Planning_Guide/topics/introduction.adoc
+++ b/doc-Deployment_Planning_Guide/topics/introduction.adoc
@@ -173,7 +173,7 @@ Zones:: {product-title} Infrastructure can be organized into zones to configure 
 Zones can be based on geographic location, network location, or function. When first started, new servers are put into the default zone.
 
 ifdef::cfme[]
-=== Getting Help with Red Hat CloudForms
+=== Getting Support
 
 If you experience difficulty with a procedure described in this documentation, visit the Red Hat Customer Portal at http://access.redhat.com. Through the Customer Portal, you can:
 

--- a/doc-Deployment_Planning_Guide/topics/introduction.adoc
+++ b/doc-Deployment_Planning_Guide/topics/introduction.adoc
@@ -30,12 +30,12 @@ A SmartProxy agent must configured in each storage location, and must be visible
 
 === Requirements
 
-To use {product-title}, certain hardware, browser, and database requirements must be met in your environment. 
+To use {product-title}, certain virtual hardware, database, and browser requirements must be met in your environment. 
 
 
-==== Hardware Requirements
+==== Virtual Hardware Requirements
 
-The {product-title} appliance requires the following hardware at minimum:
+The {product-title} appliance requires the following virtual hardware at minimum:
 
 * 4 VCPUs
 * 8 GB RAM

--- a/doc-Deployment_Planning_Guide/topics/introduction.adoc
+++ b/doc-Deployment_Planning_Guide/topics/introduction.adoc
@@ -173,7 +173,7 @@ Zones:: {product-title} Infrastructure can be organized into zones to configure 
 Zones can be based on geographic location, network location, or function. When first started, new servers are put into the default zone.
 
 ifdef::cfme[]
-=== Getting Help and Giving Feedback
+=== Getting Help with Red Hat CloudForms
 
 If you experience difficulty with a procedure described in this documentation, visit the Red Hat Customer Portal at http://access.redhat.com. Through the Customer Portal, you can:
 
@@ -183,15 +183,6 @@ If you experience difficulty with a procedure described in this documentation, v
 
 Red Hat also hosts a large number of electronic mailing lists for discussion of Red Hat software and technology.
 You can find a list of publicly available mailing lists at https://www.redhat.com/mailman/listinfo. Click on the name of any mailing list to subscribe to that list or to access the list archives.
-
-=== Documentation Feedback
-
-If you find a typographical error in this manual, or if you have thought of a way to make this manual better, please submit a report to GSS through the customer portal.
-
-When submitting a report, be sure to mention the manual's identifier: `Deployment Planning Guide`
-
-If you have a suggestion for improving the documentation, try to be as specific as possible when describing it.
-If you have found an error, please include the section number and some of the surrounding text so we can find it easily.
 endif::cfme[]
 
 

--- a/doc-Deployment_Planning_Guide/topics/introduction.adoc
+++ b/doc-Deployment_Planning_Guide/topics/introduction.adoc
@@ -30,7 +30,6 @@ A SmartProxy agent must configured in each storage location, and must be visible
 
 === Requirements
 
-//Write intro.
 To use {product-title}, certain hardware, browser, and database requirements must be met in your environment. 
 
 

--- a/doc-Deployment_Planning_Guide/topics/planning.adoc
+++ b/doc-Deployment_Planning_Guide/topics/planning.adoc
@@ -47,16 +47,6 @@ A number of approaches exist for tenant planning:
 * *Multiple tenant model (CCP)* - Created with Certified Cloud Providers in mind, this model allows multiple tenants to enjoy complete isolation from other tenants, with separate branding and unique URLs.
 
 
-=== Database Sizing Assistant
-
-Red Hat recommends allocating the virtual machine disk fully at the time of creation. Three main factors affect the size of your database over time:
-
-* Virtual Machine Count: the most important factor in the calculation of virtual machine database (VMDB) size over time.
-* Host Count: the number of hosts associated with the provider.
-* Storage Count: the number of individual storage elements as seen from the perspective of the provider or host. It is not the total number of virtual disks for all virtual machines.
-
-image:5780.png[]
-
 === Example PostgreSQL Configuration File
 
 ------

--- a/doc-General_Configuration/cfme/docinfo.xml
+++ b/doc-General_Configuration/cfme/docinfo.xml
@@ -4,9 +4,7 @@
 <subtitle>A guide to configuring and tuning Red Hat CloudForms</subtitle>
 <abstract>
     <para>This guide provides instructions on configuring CloudForms Management Engine, including appliance settings, access control, web console appearance, registration, and updates. Information and procedures in this book are relevant to CloudForms Management Engine administrators. This guide is for the Red Hat CloudForms 4.1 and Red Hat CloudForms Management Engine version 5.6.</para>
-    <para>
-      If you have suggestions for improving this guide, we would love to hear from you. Please submit a Bugzilla report at <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis> for <emphasis role="strong">Component: Documentation</emphasis>. Please be as specific as possible when submitting feedback. If you have found an error, please include the guide's title, section number, and some of the surrounding text so we can find it easily. 
-    </para>
+   <para>If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis> for the <emphasis role="strong">Documentation</emphasis> component. Please provide specific details, such as the section number, guide name, and CloudForms version so we can easily locate the content.</para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/doc-General_Configuration/cfme/docinfo.xml
+++ b/doc-General_Configuration/cfme/docinfo.xml
@@ -4,8 +4,9 @@
 <subtitle>A guide to configuring and tuning Red Hat CloudForms</subtitle>
 <abstract>
     <para>This guide provides instructions on configuring CloudForms Management Engine, including appliance settings, access control, web console appearance, registration, and updates. Information and procedures in this book are relevant to CloudForms Management Engine administrators. This guide is for the Red Hat CloudForms 4.1 and Red Hat CloudForms Management Engine version 5.6.</para>
-    <para>If you have feedback to make this guide better, we would love to hear from you. Please submit a Bugzilla report: <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against the product <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis>.</para>
-    <para>When submitting a bug report, be sure to mention the <emphasis role="strong">Component</emphasis> as <emphasis role="strong">Documentation</emphasis> and select the version of the CloudForms Management Engine against which you are raising the bug. If you have a suggestion for improving the documentation, try to be as specific as possible when describing it. If you have found an error, please include the section number and some of the surrounding text so we can find it easily.</para>
+    <para>
+      If you have suggestions for improving this guide, we would love to hear from you. Please submit a Bugzilla report at <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis> for <emphasis role="strong">Component: Documentation</emphasis>. Please be as specific as possible when submitting feedback. If you have found an error, please include the guide's title, section number, and some of the surrounding text so we can find it easily. 
+    </para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/doc-Installing_on_Google_Compute_Engine/cfme/docinfo.xml
+++ b/doc-Installing_on_Google_Compute_Engine/cfme/docinfo.xml
@@ -4,6 +4,7 @@
 <subtitle>How to install and configure Red Hat CloudForms on a Google Compute Engine environment</subtitle>
 <abstract>
     <para>This guide provides instructions on how to install and configure Red Hat CloudForms on a Google Compute Engine environment.</para>
+    <para>If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis> for the <emphasis role="strong">Documentation</emphasis> component. Please provide specific details, such as the section number, guide name, and CloudForms version so we can easily locate the content.</para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/doc-Installing_on_Microsoft_Azure/cfme/docinfo.xml
+++ b/doc-Installing_on_Microsoft_Azure/cfme/docinfo.xml
@@ -4,6 +4,7 @@
 <subtitle>How to install and configure Red Hat CloudForms on a Microsoft Azure Cloud environment</subtitle>
 <abstract>
     <para>This guide provides instructions on how to install and configure Red Hat CloudForms on a Microsoft Azure Cloud environment.</para>
+    <para>If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis> for the <emphasis role="strong">Documentation</emphasis> component. Please provide specific details, such as the section number, guide name, and CloudForms version so we can easily locate the content.</para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/doc-Installing_on_Microsoft_Azure/topics/installation.adoc
+++ b/doc-Installing_on_Microsoft_Azure/topics/installation.adoc
@@ -32,7 +32,7 @@ endif::cfme[]
 
 In order to upload the {product-title} appliance file to Microsoft Azure, ensure the following requirements are met:
 
-* Approximately 2 GB of space for each VHD image; 40+ GB for the {product-title} appliance.
+* Approximately 2 GB of space for each VHD image; 44+ GB of space, 8 GB RAM, and 4 VCPUs for the {product-title} appliance.
 * Administrator access to the Azure portal.
 * Depending on your infrastructure, allow time for the upload.
 

--- a/doc-Installing_on_Red_Hat_Enterprise_Linux_OpenStack_Platform/cfme/docinfo.xml
+++ b/doc-Installing_on_Red_Hat_Enterprise_Linux_OpenStack_Platform/cfme/docinfo.xml
@@ -4,6 +4,7 @@
 <subtitle>How to install and configure Red Hat CloudForms on a Red Hat OpenStack Platform environment</subtitle>
 <abstract>
     <para>This guide provides instructions on how to install and configure Red Hat CloudForms on a Red Hat OpenStack Platform environment.</para>
+    <para>If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis> for the <emphasis role="strong">Documentation</emphasis> component. Please provide specific details, such as the section number, guide name, and CloudForms version so we can easily locate the content.</para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/doc-Installing_on_Red_Hat_Enterprise_Linux_OpenStack_Platform/topics/installation.adoc
+++ b/doc-Installing_on_Red_Hat_Enterprise_Linux_OpenStack_Platform/topics/installation.adoc
@@ -79,7 +79,7 @@ image:4941.png[title="Add Rule Dialog"]
 A flavor is a resource allocation profile that specifies, for example, how many virtual CPUs and how much RAM can be allocated to an instance. You can, for example, run {product-title} on a Red Hat OpenStack m1.large flavor, which specifies a virtual machine with 4
 cores, 8GB RAM, and 80GB disk space. Creating a flavor to run {product-title} is optional.
 
-The following procedure demonstrates creating a flavor with the minimum requirements (4 cores, 6GB RAM, 40GB disk space) for {product-title}. For more information about flavors, see the Red Hat Enterprise Linux OpenStack Platform Administration User Guide.
+The following procedure demonstrates creating a flavor with the minimum requirements (4 cores, 8GB RAM, 44GB disk space) for {product-title}. For more information about flavors, see the Red Hat Enterprise Linux OpenStack Platform Administration User Guide.
 
 . Log in to the OpenStack dashboard as admin.
 . In the *Admin* tab, navigate to menu:System[Flavors].
@@ -89,7 +89,7 @@ The following procedure demonstrates creating a flavor with the minimum requirem
 .. Enter the following settings:
 +
 * *VCPUs*: 4
-* *RAM MB*: 6144
+* *RAM MB*: 8192
 * *Root Disk GB*: 45
 * *Ephemeral Disk GB*: 0
 * *Swap Disk MB*: 0

--- a/doc-Installing_on_Red_Hat_Enterprise_Virtualization/cfme/docinfo.xml
+++ b/doc-Installing_on_Red_Hat_Enterprise_Virtualization/cfme/docinfo.xml
@@ -4,6 +4,7 @@
 <subtitle>How to install and configure Red Hat CloudForms on a Red Hat Enterprise Virtualization environment</subtitle>
 <abstract>
     <para>This guide provides instructions on how to install and configure Red Hat CloudForms on a Red Hat Enterprise Virtualization environment.</para>
+    <para>If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis> for the <emphasis role="strong">Documentation</emphasis> component. Please provide specific details, such as the section number, guide name, and CloudForms version so we can easily locate the content.</para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/doc-Installing_on_Red_Hat_Enterprise_Virtualization/topics/installation.adoc
+++ b/doc-Installing_on_Red_Hat_Enterprise_Virtualization/topics/installation.adoc
@@ -32,6 +32,8 @@ endif::cfme[]
 Uploading the {product-title} appliance file onto Red Hat Enterprise Virtualization Management systems has the following requirements:
 
 * 44 GB of storage space on both the export domain and the local partition where `/tmp` resides since the `OVF` archive is locally expanded into that directory.
+* 8 GB RAM.
+* 4 VCPUs.
 * Install the `rhevm-image-uploader` package containing the `engine-image-uploader` script to your local machine.
 +
 ----

--- a/doc-Installing_on_VMware_vSphere/cfme/docinfo.xml
+++ b/doc-Installing_on_VMware_vSphere/cfme/docinfo.xml
@@ -4,6 +4,7 @@
 <subtitle>How to install and configure Red Hat CloudForms on a VMware vSphere environment</subtitle>
 <abstract>
     <para>This guide provides instructions on how to install and configure Red Hat CloudForms on a VMware vSphere environment.</para>
+    <para>If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis> for the <emphasis role="strong">Documentation</emphasis> component. Please provide specific details, such as the section number, guide name, and CloudForms version so we can easily locate the content.</para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/doc-Installing_on_VMware_vSphere/topics/installation.adoc
+++ b/doc-Installing_on_VMware_vSphere/topics/installation.adoc
@@ -32,6 +32,8 @@ endif::cfme[]
 Uploading the {product-title} appliance file onto VMware vSphere systems has the following requirements:
 
 * 44 GB of space on the chosen vSphere datastore.
+* 8 GB RAM.
+* 4 VCPUs.
 * Administrator access to the vSphere Client.
 * Depending on your infrastructure, allow time for the upload.
 

--- a/doc-Integration_with_AWS_CloudFormation_and_OpenStack_Heat/cfme/docinfo.xml
+++ b/doc-Integration_with_AWS_CloudFormation_and_OpenStack_Heat/cfme/docinfo.xml
@@ -4,6 +4,7 @@
 <subtitle>How to install and configure Amazon CloudFormation and OpenStack Heat in a Red Hat CloudForms environment</subtitle>
 <abstract>
     <para>This guide provides instructions on the implementation of Amazon CloudFormation and OpenStack Heat in Red Hat CloudForms, and discusses the various areas of integration. Information and procedures in this book are relevant to CloudForms Management Engine administrators.</para>
+    <para>If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis> for the <emphasis role="strong">Documentation</emphasis> component. Please provide specific details, such as the section number, guide name, and CloudForms version so we can easily locate the content.</para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/doc-Integration_with_ServiceNow/cfme/docinfo.xml
+++ b/doc-Integration_with_ServiceNow/cfme/docinfo.xml
@@ -3,8 +3,8 @@
 <productnumber>4.1</productnumber>
 <subtitle>Integrating ServiceNow CMDB with Red Hat CloudForms</subtitle>
 <abstract>
-    	<para>This guide provides instructions for using the CloudForms Management Engine features relevant to non-administrative users. It establishes basic system and operational concepts through task-based scenarios and examples.
-	</para>
+    	<para>This guide provides instructions for using the CloudForms Management Engine features relevant to non-administrative users. It establishes basic system and operational concepts through task-based scenarios and examples.</para>
+      <para>If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis> for the <emphasis role="strong">Documentation</emphasis> component. Please provide specific details, such as the section number, guide name, and CloudForms version so we can easily locate the content.</para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/doc-Introduction_to_Self_Service_Portal/cfme/docinfo.xml
+++ b/doc-Introduction_to_Self_Service_Portal/cfme/docinfo.xml
@@ -4,6 +4,7 @@
 <subtitle>An overview of the Red Hat CloudForms Self Service user interface</subtitle>
 <abstract>
     <para>This document provides an outline of the options available in the Red Hat CloudForms Self Service user interface.</para>
+    <para>If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis> for the <emphasis role="strong">Documentation</emphasis> component. Please provide specific details, such as the section number, guide name, and CloudForms version so we can easily locate the content.</para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/doc-Managing_Infrastructure_and_Inventory/cfme/docinfo.xml
+++ b/doc-Managing_Infrastructure_and_Inventory/cfme/docinfo.xml
@@ -4,6 +4,7 @@
 <subtitle>Viewing and collecting information from your clusters, hosts, virtual machines, and other resources</subtitle>
 <abstract>
    <para>This guide covers viewing and collecting information from your clusters, hosts, virtual machines, resource pools, datastores, and repositories in Red Hat CloudForms.</para>
+   <para>If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis> for the <emphasis role="strong">Documentation</emphasis> component. Please provide specific details, such as the section number, guide name, and CloudForms version so we can easily locate the content.</para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/doc-Managing_Providers/cfme/docinfo.xml
+++ b/doc-Managing_Providers/cfme/docinfo.xml
@@ -4,6 +4,7 @@
 <subtitle>Managing your infrastructure, cloud, and containers providers</subtitle>
 <abstract>
    <para>This guide covers managing your infrastructure, cloud, and containers providers in Red Hat CloudForms.</para>
+   <para>If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis> for the <emphasis role="strong">Documentation</emphasis> component. Please provide specific details, such as the section number, guide name, and CloudForms version so we can easily locate the content.</para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/doc-Methods_Available_for_Automation/cfme/docinfo.xml
+++ b/doc-Methods_Available_for_Automation/cfme/docinfo.xml
@@ -4,6 +4,7 @@
 <subtitle>Advanced automation methods for Red Hat CloudForms</subtitle>
 <abstract>
    <para>This guide provides advanced methods for CloudForms Management Engine's automation functions. Methods can be used from within CloudForms Management Engine to create custom actions and workflows for the objects managed by CloudForms Management Engine. Information and procedures in this book are relevant to CloudForms Management Engine administrators. This document is organized by the object hierarchy in the Automate Model.</para>
+   <para>If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis> for the <emphasis role="strong">Documentation</emphasis> component. Please provide specific details, such as the section number, guide name, and CloudForms version so we can easily locate the content.</para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/doc-Monitoring_Alerts_and_Reporting/cfme/docinfo.xml
+++ b/doc-Monitoring_Alerts_and_Reporting/cfme/docinfo.xml
@@ -4,6 +4,7 @@
 <subtitle>Creating and managing reports, feeds, and widgets in Red Hat CloudForms</subtitle>
 <abstract>
     <para>This guide provides instructions for creating and managing reports, feeds, and widgets in Red Hat CloudForms. It also includes information on accessing usage and timeline data, and chargeback costs. This information supports better information technology decision making and predictions for future virtual machine management.</para>
+    <para>If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis> for the <emphasis role="strong">Documentation</emphasis> component. Please provide specific details, such as the section number, guide name, and CloudForms version so we can easily locate the content.</para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/doc-Policies_and_Profiles_Guide/cfme/docinfo.xml
+++ b/doc-Policies_and_Profiles_Guide/cfme/docinfo.xml
@@ -4,6 +4,7 @@
 <subtitle>Policy-based enforcement, compliance, events, and policy profiles for Red Hat CloudForms</subtitle>
 <abstract>
     <para> This guide provides instructions for policy-based actions in a Red Hat CloudForms environment, including system controls, enforcement, compliance, and events. Information and procedures in this book are relevant to Red Hat CloudForms administrators.</para>
+    <para>If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis> for the <emphasis role="strong">Documentation</emphasis> component. Please provide specific details, such as the section number, guide name, and CloudForms version so we can easily locate the content.</para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/doc-Provisioning_Virtual_Machines_and_Hosts/cfme/docinfo.xml
+++ b/doc-Provisioning_Virtual_Machines_and_Hosts/cfme/docinfo.xml
@@ -4,6 +4,7 @@
 <subtitle>Provisioning, workload management, and orchestration for Red Hat CloudForms</subtitle>
 <abstract>
     <para>This guide provides instructions for provisioning, service creation, and automation in Red Hat CloudForms.</para>
+    <para>If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis> for the <emphasis role="strong">Documentation</emphasis> component. Please provide specific details, such as the section number, guide name, and CloudForms version so we can easily locate the content.</para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/doc-REST_API/cfme/docinfo.xml
+++ b/doc-REST_API/cfme/docinfo.xml
@@ -4,6 +4,7 @@
 <subtitle>Using the Red Hat CloudForms REST API</subtitle>
 <abstract>
    <para>This guide provides web services available to integrate Red Hat CloudForms with external applications. It details the specification of the Red Hat CloudForms RESTful API, which is implemented as standard REST HTTP requests and responses of content type JSON.</para>
+   <para>If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis> for the <emphasis role="strong">Documentation</emphasis> component. Please provide specific details, such as the section number, guide name, and CloudForms version so we can easily locate the content.</para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/doc-Scripting_Actions/cfme/docinfo.xml
+++ b/doc-Scripting_Actions/cfme/docinfo.xml
@@ -4,6 +4,7 @@
 <subtitle>Real-time, bi-directional process integration for Red Hat CloudForms</subtitle>
 <abstract>
    <para>This guide provides instructions for scripting the method to implement adaptive automation for management events and administrative or operational activities.</para>
+   <para>If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis> for the <emphasis role="strong">Documentation</emphasis> component. Please provide specific details, such as the section number, guide name, and CloudForms version so we can easily locate the content.</para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>


### PR DESCRIPTION
From https://bugzilla.redhat.com/show_bug.cgi?id=1371753:  

Added a shortened paragraph to the abstract of all docs on providing feedback. Where there was already instructions on submitting docs feedback, removed it (Deployment Planning Guide).  

Suyog, thank you for your initial advice with wording, and for reviewing this PR.  :)