### PR TITLE
Added step to specify a zone

### DIFF
--- a/common/provider-ose-add-container.adoc
+++ b/common/provider-ose-add-container.adoc
@@ -1,7 +1,7 @@
 . Navigate to menu:Compute[Containers > Providers].
 . Click  image:1847.png[Configuration] (*Configuration*), then click  image:1862.png[Add a New Containers Provider] (*Add a New Containers Provider*).
 . Enter a *Name* for the provider.
-. From the *Type* drop-down list, select *OpenShift Enterprise*.
+. From the *Type* list, select *OpenShift Enterprise*.
 . Enter the appropriate *Zone* for the provider. By default, the zone is set to `default`.
 . Enter the *Hostname or IP address* of the provider.
 +

--- a/common/provider-ose-add-container.adoc
+++ b/common/provider-ose-add-container.adoc
@@ -1,7 +1,8 @@
 . Navigate to menu:Compute[Containers > Providers].
 . Click  image:1847.png[Configuration] (*Configuration*), then click  image:1862.png[Add a New Containers Provider] (*Add a New Containers Provider*).
 . Enter a *Name* for the provider.
-. From the *Type* drop-down menu select *OpenShift Enterprise*.
+. From the *Type* drop-down list, select *OpenShift Enterprise*.
+. Enter the appropriate *Zone* for the provider. By default, the zone is set to `default`.
 . Enter the *Hostname or IP address* of the provider.
 +
 [IMPORTANT]

--- a/doc-Managing_Providers/cfme/master.adoc
+++ b/doc-Managing_Providers/cfme/master.adoc
@@ -14,6 +14,18 @@ include::common/attributes/cfme.adoc[]
 
 :numbered:
 
+What is a provider in CloudForms?
+
+From http://manageiq.org/documentation/development/architecture/providers_overview/
+
+Providers are management systems that integrate with {product-title}.
+
+any system that {product-title} integrates with for the purpose of collecting data and performing operations.
+
+You can add your providers into CloudForms and use CloudForms to manage and provision your resources (hosts, VMs etc) from a single unified platform.
+
+There are several different types (categories?) of providers Compute, Configuration Management, Networking
+
 :leveloffset: 1
 include::topics/Infrastructure_Providers.adoc[]
 

--- a/doc-Managing_Providers/cfme/master.adoc
+++ b/doc-Managing_Providers/cfme/master.adoc
@@ -14,18 +14,6 @@ include::common/attributes/cfme.adoc[]
 
 :numbered:
 
-What is a provider in CloudForms?
-
-From http://manageiq.org/documentation/development/architecture/providers_overview/
-
-Providers are management systems that integrate with {product-title}.
-
-any system that {product-title} integrates with for the purpose of collecting data and performing operations.
-
-You can add your providers into CloudForms and use CloudForms to manage and provision your resources (hosts, VMs etc) from a single unified platform.
-
-There are several different types (categories?) of providers Compute, Configuration Management, Networking
-
 :leveloffset: 1
 include::topics/Infrastructure_Providers.adoc[]
 


### PR DESCRIPTION
On the cf-tech list, David La Motta noticed we were missing a step to specify the zone when adding an OpenShift provider. No bug was created for this, as Loic requested just the addition of one line:

"Select the appropriate Zone for the provider. By default, the zone is set to default."

I looked into putting some info about why to choose which zone, but we've already covered it well in the Deployment Planning and the Gen Config Guides.