### PR TITLE
Removed leveloffset from REST API Guide

### DIFF
--- a/doc-REST_API/cfme/master.adoc
+++ b/doc-REST_API/cfme/master.adoc
@@ -12,13 +12,10 @@ include::common/attributes/cfme.adoc[]
 :cfme:
 
 :numbered:
-:leveloffset: 1
 include::topics/chap-Specification.adoc[]
 
-:leveloffset: 1
 include::topics/chap-Reference_Guide.adoc[]
 
-:leveloffset: 1
 include::topics/chap-Examples.adoc[]
 
 


### PR DESCRIPTION
Removed leveloffsets from the REST API Guide. (This also fixes the problem of the downstream guide having no table of contents.)