### PR TITLE
Bz1383126 storageprofiles

### DIFF
--- a/doc-Managing_Infrastructure_and_Inventory/topics/Viewing_VMware_Storage_Profiles.adoc
+++ b/doc-Managing_Infrastructure_and_Inventory/topics/Viewing_VMware_Storage_Profiles.adoc
@@ -1,7 +1,7 @@
 [[viewing_vmware_storage_profiles]]
 = Viewing a VMware Virtual Machine's Storage Profile
 
-VMware storage profiles allow you to assign specific policies to datastores. Storage profiles are used to tag virtual machines to ensure they operate in compliance with settings in the datastore.
+VMware storage profiles allow you to assign policies to datastores. Storage profiles are used to tag virtual machines to ensure they operate in compliance with settings in the datastore.
 
 {product-title} retrieves VMware virtual machine storage profile information in the inventory, and associates the virtual machines and disks with them.
 

--- a/doc-Managing_Infrastructure_and_Inventory/topics/Viewing_VMware_Storage_Profiles.adoc
+++ b/doc-Managing_Infrastructure_and_Inventory/topics/Viewing_VMware_Storage_Profiles.adoc
@@ -11,7 +11,5 @@ To view a virtual machine's storage profile:
 . Click a VMware virtual machine to open its summary page.
 . The VMware *Storage Profile* is listed under *Properties*.
 
-The virtual machine can be used as a template for provisioning. See [*ADD LINK TO PROVISIONING PROCEDURE*] for instructions.
-
-
+You can assign a storage profile when provisioning a VMware virtual machine in {product-title}, by using the virtual machine as a template to clone. See https://access.redhat.com/documentation/en/red-hat-cloudforms/4.2-beta/single/provisioning-virtual-machines-and-hosts/#provisioning-virtual-machines[Provisioning Virtual Machines] in _Provisioning Virtual Machines and Hosts_ for instructions.
 

--- a/doc-Managing_Infrastructure_and_Inventory/topics/Viewing_VMware_Storage_Profiles.adoc
+++ b/doc-Managing_Infrastructure_and_Inventory/topics/Viewing_VMware_Storage_Profiles.adoc
@@ -1,0 +1,17 @@
+[[viewing_vmware_storage_profiles]]
+= Viewing a VMware Virtual Machine's Storage Profile
+
+VMware storage profiles allow you to assign specific policies to datastores. Storage profiles are used to tag virtual machines to ensure they operate in compliance with settings in the datastore.
+
+{product-title} retrieves VMware virtual machine storage profile information in the inventory, and associates the virtual machines and disks with them.
+
+To view a virtual machine's storage profile:
+
+. Navigate to menu:Compute[Infrastructure > Virtual Machines].
+. Click a VMware virtual machine to open its summary page.
+. The VMware *Storage Profile* is listed under *Properties*.
+
+The virtual machine can be used as a template for provisioning. See [*ADD LINK TO PROVISIONING PROCEDURE*] for instructions.
+
+
+

--- a/doc-Managing_Infrastructure_and_Inventory/topics/Virtual_Machines.adoc
+++ b/doc-Managing_Infrastructure_and_Inventory/topics/Virtual_Machines.adoc
@@ -241,6 +241,10 @@ include::To_tag_Virtual_Machines_and_Templates.adoc[]
 
 
 :leveloffset: 2
+include::Viewing_VMware_Storage_Profiles.adoc[]
+
+
+:leveloffset: 2
 include::To_view_running_processes_after_collection.adoc[]
 
 

--- a/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Provisioning_Requests.adoc
+++ b/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Provisioning_Requests.adoc
@@ -351,7 +351,7 @@ image:2328.png[]
 .. Under *Count*, select the number of virtual machines you want to create in this request.
 .. Use *Naming* to specify a *VM Name* and *VM Description*. When provisioning multiple virtual machines, a number will be appended to the *VM Name*.
 . Click the *Environment* tab to decide where you want the new virtual machines to reside.
-.. If provisioning from a template on VMware, you can either let {product-title} decide for you by checking *Choose Automatically*, or select a specific cluster, resource pool, folder, host, and datastore. VMware virtual machines can also be provisioned to a clustered datastore by selecting it under *Datastore*. Additionally, you can assign a storage profile to a VMware virtual machine under *Datastore* to configure the virtual machine to operate using a storage policy from that datastore.
+.. If provisioning from a template on VMware, you can either let {product-title} decide for you by checking *Choose Automatically*, or select a specific cluster, resource pool, folder, host, and datastore. VMware virtual machines can also be provisioned to a clustered datastore by selecting it under *Datastore*. Additionally, you can assign a storage profile to a VMware virtual machine under *Datastore* to configure the virtual machine to operate using a storage profile from that datastore.
 +
 Note, read-only datastores are excluded when provisioning a virtual machine.
 +

--- a/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Provisioning_Requests.adoc
+++ b/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Provisioning_Requests.adoc
@@ -351,7 +351,7 @@ image:2328.png[]
 .. Under *Count*, select the number of virtual machines you want to create in this request.
 .. Use *Naming* to specify a *VM Name* and *VM Description*. When provisioning multiple virtual machines, a number will be appended to the *VM Name*.
 . Click the *Environment* tab to decide where you want the new virtual machines to reside.
-.. If provisioning from a template on VMware, you can either let {product-title} decide for you by checking *Choose Automatically*, or select a specific cluster, resource pool, folder, host, and datastore. VMware virtual machines can also be provisioned to a clustered datastore by selecting it under *Datastore*. Additionally, you can assign a storage profile to a VMware virtual machine under *Datastore*.
+.. If provisioning from a template on VMware, you can either let {product-title} decide for you by checking *Choose Automatically*, or select a specific cluster, resource pool, folder, host, and datastore. VMware virtual machines can also be provisioned to a clustered datastore by selecting it under *Datastore*. Additionally, you can assign a storage profile to a VMware virtual machine under *Datastore* to configure the virtual machine to operate using a storage policy from that datastore.
 +
 Note, read-only datastores are excluded when provisioning a virtual machine.
 +

--- a/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Provisioning_Requests.adoc
+++ b/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Provisioning_Requests.adoc
@@ -351,7 +351,7 @@ image:2328.png[]
 .. Under *Count*, select the number of virtual machines you want to create in this request.
 .. Use *Naming* to specify a *VM Name* and *VM Description*. When provisioning multiple virtual machines, a number will be appended to the *VM Name*.
 . Click the *Environment* tab to decide where you want the new virtual machines to reside.
-.. If provisioning from a template on VMware, you can either let {product-title} decide for you by checking *Choose Automatically*, or select a specific cluster, resource pool, folder, host, and datastore. VMware virtual machines can also be provisioned to a clustered datastore by selecting it under *Datastore*.
+.. If provisioning from a template on VMware, you can either let {product-title} decide for you by checking *Choose Automatically*, or select a specific cluster, resource pool, folder, host, and datastore. VMware virtual machines can also be provisioned to a clustered datastore by selecting it under *Datastore*. Additionally, you can assign a storage profile to a VMware virtual machine under *Datastore*.
 +
 Note, read-only datastores are excluded when provisioning a virtual machine.
 +
@@ -415,7 +415,7 @@ Virtual machines can be cloned in other providers as well.
 . Schedule the request on the *Schedule* tab.
 . Click *Submit*.
 
-[[publishing-a-virtual-machine-to-a-template-(vmware-virtual-machines-only)]]
+[[publishing-a-virtual-machine-to-a-template-vmware]]
 ==== Publishing a Virtual Machine to a Template (VMware Virtual Machines Only)
 
 . Navigate to menu:Compute[Infrastructure > Virtual Machines], and check the virtual machine you want to publish as a template.


### PR DESCRIPTION
Hi Chris,

I've added info about CloudForms' integration with VMware storage profiles to two guides - can you please review?

**Managing Infrastructure and Inventory** - for instructions on viewing profile information

---> Preview: http://file.bne.redhat.com/~dayparke/CloudForms/Storageprofile-Managinginfra/build/tmp/en-US/html-single/#viewing_vmware_storage_profiles

**Provisioning VMs and Hosts** - for instructions on how to apply a storage profile to a VM (only available when provisioning at the moment - see Comment 6)

---> Preview: http://file.bne.redhat.com/~dayparke/CloudForms/Storageprofile-Provisioningguide/build/tmp/en-US/html-single/#provisioning-a-virtual-machine-from-a-template (changes made to step 10)

Please let me know if you have any feedback. I was debating whether to add a screenshot to show where the storage profile displays in the CF UI (see the feature demo here for more info https://youtu.be/CCHlZiFWikM?t=14m1s), but have left it out for now. Does the content make sense as it is now?

Opinions welcome on the best place in the Virtual Machines chapter to put the Viewing VMware Storage Profiles section -- it's vaguely like a tag, so I added it around that content. I'm unsure of the logic of that chapter order, myself :)

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1383126

Thanks,
Dayle