### PR TITLE
Example: Add OpenStack provider via API

### DIFF
--- a/api/examples/create_provider.adoc
+++ b/api/examples/create_provider.adoc
@@ -1,6 +1,11 @@
 
 [[create-provider]]
-=== Create Provider
+== Create Provider
+
+Please refer link:../appendices/provider_types.adoc[Provider Types] to
+view all provider types.
+
+=== RHEVM
 
 ==== Request:
 
@@ -43,3 +48,46 @@ POST /api/providers
 }
 ----
 
+=== OpenStack
+
+==== Request:
+
+----
+POST /api/providers
+----
+
+[source,json]
+----
+{
+  "type"      : "ManageIQ::Providers::Openstack::CloudManager",
+  "name"      : "OpenStack001",
+  "hostname"  : "OpenStack001",
+  "ipaddress" : "10.65.8.133",
+  "credentials" : {
+    "userid"    : "admin",
+    "password"  : "admin_password"
+  }
+}
+----
+
+==== Response:
+
+[source,json]
+----
+{
+  "results": [
+    {
+      "id": 21000000000006,
+      "name": "OpenStack001",
+      "hostname": "OpenStack001",
+      "ipaddress": "10.65.8.133",
+      "created_on": "2016-09-27T09:18:31Z",
+      "updated_on": "2016-09-27T09:18:31Z",
+      "guid": "5befc378-8493-11e6-92d5-525400b18796",
+      "zone_id": 21000000000001,
+      "type": "ManageIQ::Providers::Openstack::CloudManager",
+      "tenant_id": 21000000000001
+    }
+  ]
+}
+----


### PR DESCRIPTION
W.r.t http://talk.manageiq.org/t/how-to-create-openstack-provider-via-api/1688/,
there is no example to add OpenStack provider. Although the request is
similar but response changes with provider. I have also added link to
"Provider Types" so that it is easy to refer the list while making API
request.
