### PR TITLE
add note about enabling Google Cloud Monitoring API

### DIFF
--- a/doc-Deployment_Planning_Guide/topics/capacity.adoc
+++ b/doc-Deployment_Planning_Guide/topics/capacity.adoc
@@ -33,10 +33,7 @@ creation of capacity and utilization.
   This role has a dedicated worker, and there can be more than one
   server with this role in a zone.
 
-[NOTE]
-====
-{product-title_short} can collect capacity and utilization metrics from Google Compute Engine once Google Cloud Monitoring API is enabled. Visit the Google APIs API Manager site to enable the Google Cloud Monitoring API. Once enabled, it may take a few minutes to propgate to {product-title_short}.
-====
+
 
 
 [[assigning_the_capacity_and_utilization_server_roles]]
@@ -279,6 +276,12 @@ ifdef::miq[Managing Providers]
   After adding the provider, capacity and utilization data for your instances
   populate in a few minutes.
 
+[[data_collection_for_gce]]
+=== Data Collection for Google Compute Engine
+  
+{product-title} can collect capacity and utilization metrics from Google Compute Engine once Google Cloud Monitoring API is enabled. Visit the Google APIs API Manager site to enable the Google Cloud Monitoring API. Once enabled, it may take a few minutes to propgate to {product-title_short}.
+
+  
 [[data_collected]]
 === Data Collected
 

--- a/doc-Deployment_Planning_Guide/topics/capacity.adoc
+++ b/doc-Deployment_Planning_Guide/topics/capacity.adoc
@@ -279,7 +279,10 @@ ifdef::miq[Managing Providers]
 [[data_collection_for_gce]]
 === Data Collection for Google Compute Engine
   
-{product-title} can collect capacity and utilization metrics from Google Compute Engine once Google Cloud Monitoring API is enabled. Visit the Google APIs API Manager site to enable the Google Cloud Monitoring API. Once enabled, it may take a few minutes to propgate to {product-title_short}.
+{product-title} can collect capacity and utilization metrics from 
+Google Compute Engine once Google Cloud Monitoring API is enabled. 
+Visit https://console.developers.google.com/[Google API Console] to enable the Cloud Monitoring API. 
+Once enabled, it may take a few minutes to propgate to {product-title_short}.
 
   
 [[data_collected]]

--- a/doc-Deployment_Planning_Guide/topics/capacity.adoc
+++ b/doc-Deployment_Planning_Guide/topics/capacity.adoc
@@ -33,6 +33,12 @@ creation of capacity and utilization.
   This role has a dedicated worker, and there can be more than one
   server with this role in a zone.
 
+[NOTE]
+====
+{product-title_short} can collect capacity and utilization metrics from Google Compute Engine once Google Cloud Monitoring API is enabled. Visit the Google APIs API Manager site to enable the Google Cloud Monitoring API. Once enabled, it may take a few minutes to propgate to {product-title_short}.
+====
+
+
 [[assigning_the_capacity_and_utilization_server_roles]]
 === Assigning the Capacity and Utilization Server Roles
 


### PR DESCRIPTION
Hey Suyog,

I've added a note here about enabling the Google API in order to collect C&U metrics. Here's a preview of the doc:

http://file.rdu.redhat.com/~cbudzilo/CloudForms/test1/build/tmp/en-US/html-single/#capacity-and-utilization-collection

Please let me know what you think.

-Chris