### PR TITLE
BZ1420206 - Fixes to "Reintroducing the failed node" - euwe

### DIFF
--- a/doc-Configuring_High_Availability/topics/Database_Failover.adoc
+++ b/doc-Configuring_High_Availability/topics/Database_Failover.adoc
@@ -140,11 +140,13 @@ For more information on the WAL log, see the https://www.postgresql.org/docs/9.5
 # systemctl enable rh-postgresql95-repmgr
 ------
 +
-. To apply the changes, stop the cluster, then restart the service:
+. To apply the changes, stop the cluster, then restart the service as the `postgres` user:
 +
 ------
-# pg_ctl -D $APPLIANCE_PG_DATA stop
-# systemctl start $APPLIANCE_PG_SERVICE
+# su - postgres
+$ pg_ctl -D $APPLIANCE_PG_DATA stop
+$ pg_ctl -D $APPLIANCE_PG_DATA status
+$ exit
 ------
 
 Your {product-title_short} environment is now re-configured for high availability.

--- a/doc-Configuring_High_Availability/topics/Database_Failover.adoc
+++ b/doc-Configuring_High_Availability/topics/Database_Failover.adoc
@@ -68,7 +68,8 @@ To reintroduce the failed node:
 . Run `pg_rewind` on the failed primary server as the `postgres` user:
 +
 ------
-# pg_rewind -D $APPLIANCE_PG_DATA --source-server="host=<new_master_ip> user=root password=<db_password> dbname=vmdb_production"
+# su - postgres
+$ pg_rewind -D $APPLIANCE_PG_DATA --source-server="host=<new_master_ip> user=root password=<db_password> dbname=vmdb_production"
 ------
 +
 . Add the following lines for standby configuration to the `/etc/repmgr.conf` file:
@@ -80,24 +81,70 @@ follow_command='repmgr standby follow'
 logfile=/var/log/repmgr/repmgrd.log
 ------
 +
-. Copy over `/var/lib/pgsql/.pgpass` from the new primary server to the failed primary server.
+. Copy the `/var/lib/pgsql/.pgpass` file from the new primary server to the failed primary server. Change the file's ownership to the `postgres` user and group, and the permissions to 600:
++
+------
+# chown postgres:postgres /var/lib/pgsql/.pgpass
+# chmod 600 /var/lib/pgsql/.pgpass
+------
++
 . Run `repmgr standby follow` as the `postgres` user on the failed primary server to add it as a standby server:
 +
 ------
-# repmgr -f /etc/repmgr.conf -D $APPLIANCE_PG_DATA -h <new_master_ip> -U root -d vmdb_production standby follow
+# su - postgres
+$ repmgr -f /etc/repmgr.conf -D $APPLIANCE_PG_DATA -h <new_master_ip> -U root -d vmdb_production standby follow
 ------
 +
-[NOTE]
-====
-If the `follow` command times out and `postgresql.log` reports a message similar to `requested WAL segment 000000020000000000000004 has already been removed`, you can correct this by removing the contents of the data directory and reinitializing the standby as described in xref:configuring_standby_db[] to re-add the node. 
-
-This occurs when the write ahead log (WAL) required to catch up the standby server is no longer available on the primary. See the https://www.postgresql.org/docs/9.5/static/continuous-archiving.html[PostgreSQL documentation] for more information on the WAL log.
-====
+If the `follow` command times out and `postgresql.log` reports a message similar to `requested WAL segment 000000020000000000000004 has already been removed`, you can correct this by removing the contents of the data directory and reinitializing the standby to re-add the node. This occurs when the write ahead log (WAL) required to catch up the standby server is no longer available on the primary.
++
+Correct this by running the following steps:
++
+.. Delete all database data and the replication manager configuration file from failed node:
++
+----
+# rm -rf /var/opt/rh/rh-postgresql95/lib/pgsql/data/*
+# rm /etc/repmgr.conf
+----
++
+.. Delete the failed database node entry from new primary database appliance:
+... Check the failed node ID from the output and delete the entry; the ID is the same as the cluster ID provided during installation. 
+... Delete the node. For example, if the cluster ID is `1`, run `vmdb_production=#delete from repl_nodes where id = 1` to delete the failed node:
++
+----
+# psql vmdb_production
+vmdb_production=#select * from repl_nodes
+vmdb_production=#delete from repl_nodes table where id = $cluster_node_id_of_failed node
+----
++
+.. Delete the replication slot information for the failed database node. 
+... Check the `replication_slot` information for the failed node in the `pg_replication_slots` table:
+* The failed node is marked with `f` in the `active` column in the `pg_replication_slots` table. If it is `t`, there is a standby database appliance connected with ID 1; this appliance must be shut down before deleting the replication slot. 
+* When the standby node is disconnected, the active column will be changed to `f`.
+... Delete the slot:
+* The slot number is the same as the `cluster_id`; then delete the replication slot. For example, if the cluster ID is `1`, run `vmdb_production=#select pg_drop_replication_slot('repmgr_slot_1')` to delete the slot:
++
+----
+# psql vmdb_production
+vmdb_production=#select * from pg_replication_slots
+vmdb_production=#select pg_drop_replication_slot('repmgr_slot_$failed_node_cluster_id')
+----
++
+.. Reinitialize the standby database as described in xref:configuring_standby_db[] to re-add the node.
++
+For more information on the WAL log, see the https://www.postgresql.org/docs/9.5/static/continuous-archiving.html[PostgreSQL documentation].
 +
 . Start and enable `repmgrd` for automatic failover:
 +
 ------
-# systemctl start rh-postgresql95-repmgr && systemctl enable rh-postgresql95-repmgr
+# systemctl start rh-postgresql95-repmgr
+# systemctl enable rh-postgresql95-repmgr
 ------
++
+. Reboot the appliance:
++
+------
+# reboot
+------
+
 
 Your {product-title_short} environment is now re-configured for high availability.

--- a/doc-Configuring_High_Availability/topics/Database_Failover.adoc
+++ b/doc-Configuring_High_Availability/topics/Database_Failover.adoc
@@ -95,7 +95,7 @@ logfile=/var/log/repmgr/repmgrd.log
 $ repmgr -f /etc/repmgr.conf -D $APPLIANCE_PG_DATA -h <new_master_ip> -U root -d vmdb_production standby follow
 ------
 +
-If the `follow` command times out and `postgresql.log` reports a message similar to `requested WAL segment 000000020000000000000004 has already been removed`, you can correct this by removing the contents of the data directory and reinitializing the standby to re-add the node. This occurs when the write ahead log (WAL) required to catch up the standby server is no longer available on the primary.
+If the `repmgr standby follow` command times out and `postgresql.log` reports a message similar to `requested WAL segment 000000020000000000000004 has already been removed`, you can correct this by removing the contents of the data directory and reinitializing the standby to re-add the node. This occurs when the write ahead log (WAL) required to catch up the standby server is no longer available on the primary.
 +
 Correct this by running the following steps:
 +

--- a/doc-Configuring_High_Availability/topics/Database_Failover.adoc
+++ b/doc-Configuring_High_Availability/topics/Database_Failover.adoc
@@ -140,11 +140,11 @@ For more information on the WAL log, see the https://www.postgresql.org/docs/9.5
 # systemctl enable rh-postgresql95-repmgr
 ------
 +
-. Reboot the appliance:
+. To apply the changes, stop the cluster, then restart the service:
 +
 ------
-# reboot
+# pg_ctl -D $APPLIANCE_PG_DATA stop
+# systemctl start $APPLIANCE_PG_SERVICE
 ------
-
 
 Your {product-title_short} environment is now re-configured for high availability.

--- a/doc-Configuring_High_Availability/topics/Installation.adoc
+++ b/doc-Configuring_High_Availability/topics/Installation.adoc
@@ -9,6 +9,15 @@ This chapter outlines the steps for installing and configuring the {product-titl
 The primary database appliance functions as an external database to the standard {product-title_short} appliances.
 
 . Deploy a {product-title_short} appliance with an extra partition for the database at a size appropriate for your deployment. For recommendations on disk space, see https://access.redhat.com/documentation/en/red-hat-cloudforms/4.2/paged/deployment-planning-guide/chapter-2-planning[Planning] in the _Deployment Planning Guide_.
+. Configure time synchronization on the appliance:
+.. Edit `/etc/chronyd.conf` with valid NTP server information.
+.. Re-synchronize time information across the appliances:
++
+------
+# systemctl enable chronyd.service
+# systemctl start chronyd.service
+------
++
 . SSH into the {product-title_short} appliance to enter the appliance console.
 . Configure the hostname by selecting *Set Hostname*.
 . Configure networking as desired by selecting the *Set DHCP Network Configuration* or *Set Static Network Configuration* option.
@@ -61,6 +70,15 @@ The hostname must be visible to all appliances that communicate with this databa
 Configure a standard {product-title_short} appliance to point to the primary database server. This appliance does not serve as a database server. From the standard appliance, you can then configure the database itself.
 
 . Deploy a {product-title_short} appliance with an extra partition for the database at a size appropriate for your deployment. For recommendations on disk space, see https://access.redhat.com/documentation/en/red-hat-cloudforms/4.2/paged/deployment-planning-guide/chapter-2-planning[Planning] in the _Deployment Planning Guide_.
+. Configure time synchronization on the appliance:
+.. Edit `/etc/chronyd.conf` with valid NTP server information.
+.. Re-synchronize time information across the appliances:
++
+------
+# systemctl enable chronyd.service
+# systemctl start chronyd.service
+------
++
 . SSH into the {product-title_short} appliance to enter the appliance console.
 . Configure the hostname by selecting *Set Hostname*.
 . Configure networking as desired by selecting the *Set DHCP Network Configuration* or *Set Static Network Configuration* option.
@@ -91,6 +109,15 @@ You can check the configuration on the appliance console details screen. When co
 The standby database appliance is a copy of the primary database appliance and takes over the role of primary database in case of failure.
 
 . Deploy a {product-title_short} appliance with an extra partition for the database at a size appropriate for your deployment. For recommendations on disk space, see https://access.redhat.com/documentation/en/red-hat-cloudforms/4.2/paged/deployment-planning-guide/chapter-2-planning[Planning] in the _Deployment Planning Guide_.
+. Configure time synchronization on the appliance:
+.. Edit `/etc/chronyd.conf` with valid NTP server information.
+.. Re-synchronize time information across the appliances:
++
+------
+# systemctl enable chronyd.service
+# systemctl start chronyd.service
+------
++
 . SSH into the {product-title_short} appliance to enter the appliance console.
 . Configure the hostname by selecting *Set Hostname*.
 . Configure networking as desired by selecting the *Set DHCP Network Configuration* or *Set Static Network Configuration* option.
@@ -100,6 +127,14 @@ The standby database appliance is a copy of the primary database appliance and t
 === Configuring the Standby Database Appliance
 
 The steps to configure the standby database appliance are similar to that of the primary database appliance, in that they prepare the appliance to be database-only, but as the standby.
+
+[NOTE]
+====
+The current {product-title_short} version contains a known limitation when configuring a dedicated database disk from the appliance console menu.
+
+To work around this, create and mount the dedicated database partition manually with the same information from the primary database, before configuring the standby database appliance as below.
+See https://bugzilla.redhat.com/show_bug.cgi?id=1412940 for more information.
+====
 
 On the standby database appliance, configure the following:
 
@@ -133,6 +168,15 @@ Install a second virtual machine with a standard {product-title_short} appliance
 
 
 . Deploy a {product-title_short} appliance with an extra partition for the database at a size appropriate for your deployment. For recommendations on disk space, see https://access.redhat.com/documentation/en/red-hat-cloudforms/4.2/paged/deployment-planning-guide/chapter-2-planning[Planning] in the _Deployment Planning Guide_.
+. Configure time synchronization on the appliance:
+.. Edit `/etc/chronyd.conf` with valid NTP server information.
+.. Re-synchronize time information across the appliances:
++
+------
+# systemctl enable chronyd.service
+# systemctl start chronyd.service
+------
++
 . SSH into the {product-title_short} appliance to enter the appliance console.
 . Configure the hostname by selecting *Set Hostname*.
 . Configure networking as desired by selecting the *Set DHCP Network Configuration* or *Set Static Network Configuration* option.

--- a/doc-Configuring_High_Availability/topics/Installation.adoc
+++ b/doc-Configuring_High_Availability/topics/Installation.adoc
@@ -91,6 +91,12 @@ Configure a standard {product-title_short} appliance to point to the primary dat
 .. Enter the path of the remote encryption key. (For example, `/var/www/miq/vmdb/certs/v2_key`.)
 . Configure the database:
 .. Select *Create Region in External Database*, since the database is external to the appliances.
++
+[IMPORTANT]
+====
+Creating a database region will destroy any existing data and cannot be undone.
+====
++
 .. Provide the primary database appliance as the remote key location and its credentials.
 .. Assign a unique database region number. Note that creating a database region will destroy any existing data and cannot be undone.
 .. For *Are you sure you want to continue?* Select `y`.
@@ -153,7 +159,7 @@ On the standby database appliance, configure the following:
 The hostname must be visible to all appliances that communicate with this database, including the engine appliances and any global region databases.
 ====
 +
-.. Select `y` to configure Replication Manager for automatic failover.
+.. Select `y` to configure the replication manager for automatic failover.
 .. Confirm that the replication standby server configuration details are correct, and select `y` to apply the configuration.
 
 The standby server will then run an initial synchronization with the primary database, and start locally in standby mode.

--- a/doc-Configuring_High_Availability/topics/Overview.adoc
+++ b/doc-Configuring_High_Availability/topics/Overview.adoc
@@ -21,12 +21,9 @@ For a high availability {product-title} environment, you need a virtualization h
 
 ifdef::cfme[]
 See https://access.redhat.com/documentation/en/red-hat-cloudforms/4.2/paged/deployment-planning-guide/chapter-2-planning[Planning] in the _Deployment Planning Guide_ for information on setting up the correct disk space for the database appliances.
-
-Red Hat recommends using a DNS server for a high availability configuration, as DNS names can be updated more quickly than IP addresses when restoring an operation in a different location, network, or datacenter.
 endif::cfme[]
 
-
-[NOTE]
+[IMPORTANT]
 ====
 It is essential to use the same {product-title} appliance template version to install each virtual machine in this environment. 
 
@@ -34,3 +31,12 @@ ifdef::cfme[]
 See the https://access.redhat.com/products/red-hat-cloudforms[Red Hat Customer Portal] to obtain the appliance download for the platform you are running {product-title_short} on.
 endif::cfme[]
 ====
+
+Correct time synchronization is required before installing the cluster. After installing the appliances, configure time synchronization on all appliances using `chronyd`.
+
+ifdef::cfme[]
+[NOTE]
+====
+Red Hat recommends using a DNS server for a high availability configuration, as DNS names can be updated more quickly than IP addresses when restoring an operation in a different location, network, or datacenter.
+====
+endif::cfme[]


### PR DESCRIPTION
Hi Suyog,'

This is the same changes as in https://github.com/ManageIQ/manageiq_docs/pull/272, but for euwe.

I've made a lot of changes to 3.3. Reintroducing the Failed Node following feedback from a customer case. This also resulted in some more steps being added in to the installation procedures, plus a note about time synch in the Requirements chapter.

Would you mind having a look and letting me know if you spot anything confusing or needing a fix?
http://file.bne.redhat.com/~dayparke/CloudForms/HAfailednode-3/build/tmp/en-US/html-single/

Thanks so much,
Dayle