### PR TITLE
Bz1431869 rh vproviders

### DIFF
--- a/doc-Managing_Providers/topics/Adding_a_Red_Hat_Virtualization_Manager_Provider.adoc
+++ b/doc-Managing_Providers/topics/Adding_a_Red_Hat_Virtualization_Manager_Provider.adoc
@@ -7,6 +7,8 @@ After initial installation and creation of a {product-title} environment, add a 
 . Enter the *Name* of the provider to add.
   The *Name* is how the device is labeled in the console.
 . Select *Red Hat Virtualization Manager* from the *Type* list.
+. Select the appropriate *Zone* for the provider.
+  By default, the zone is set to *default*.
 . Enter the *Host Name or IP address(IPv4 or IPv6)* of the provider.
 +
 [IMPORTANT]
@@ -14,18 +16,23 @@ After initial installation and creation of a {product-title} environment, add a 
 The *Host Name* must use a unique fully qualified domain name.
 ====
 . Enter the *API Port* if your provider uses a non-standard port for access.
-. Select the appropriate *Zone* for the provider.
-  By default, the zone is set to *default*.
+. Select *Yes* or *No* to *Verify TLS Certificates*.
+. To use a CA certificate to authenticate the provider, paste the the text of the certificate in *Trusted CA Certificates* in PEM format.
++
+////
+Was:
 . In the *Credentials* area, under *Default*, provide the login credentials required for the Red Hat Virtualization Manager administrative user:
 * Enter the user name, `admin@internal`, in the *Username* field.
 * Enter the password in the *Password* field.
 * Confirm the password in the *Confirm Password* field.
 * Click *Validate* to confirm {product-title} can connect to the Red Hat Virtualization Manager.
-. Under *C & U Database* tab, provide the login credentials for the {product-title} user of the Red Hat Virtualization Data Warehouse database:
+////
+. Specify the credentials for the provider and click *Validate*.
+. Under the *C & U Database* tab, configure capacity and utilization metrics collection by providing login credentials for the {product-title} user of the Red Hat Virtualization Data Warehouse database. You can also configure this later by editing the provider.
 +
 [IMPORTANT]
 ====
-To collect capacity and utilization data, you must enable the capacity and utilization server roles available from the settings menu, menu:Configuration[Server > Server Control]. For more information on capacity and utilization collection, see "Assigning the Capacity and Utilization Server Roles" in the _Deployment Planning Guide_.
+To collect capacity and utilization data, you must enable the capacity and utilization server roles available from the settings menu, menu:Configuration[Server > Server Control]. For more information on capacity and utilization collection, see https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.5-beta/html-single/deployment_planning_guide/#assigning_the_capacity_and_utilization_server_roles[Assigning the Capacity and Utilization Server Roles] in the _Deployment Planning Guide_.
 ====
 +
 [IMPORTANT]
@@ -40,23 +47,16 @@ To install the Data Warehouse and Reports components in a Red Hat Virtualization
 
 ifdef::cfme[To create a {product-title} user in the Data Warehouse database, see https://access.redhat.com/documentation/en/red-hat-cloudforms/4.5/deployment-planning-guide/#data_collection_for_rhev_33_34[Data Collection for Red Hat Enterprise Virtualization 3.3 and 3.4] in the _Deployment Planning Guide_.]
 ifdef::miq[To create a {product-title} user in the Data Warehouse database, see "Data Collection for Red Hat Enterprise Virtualization 3.3 and 3.4" in the _Deployment Planning Guide_.]
-`
 ====
 +
+* Enter the database hostname in the *Hostname* field.
+* Enter the *API Port*.
+* Enter the *Database Name*
 * Enter the database user name in the *Username* field.
 * Enter the user password in the *Password* field.
 * Confirm the user password in the *Confirm Password* field.
 * Click *Validate* to confirm {product-title} can connect to the database.
-. Click *Save*.
-
-
-
-
-
-
-
-
-
+. Click *Add*.
 
 
 

--- a/doc-Managing_Providers/topics/Adding_a_Red_Hat_Virtualization_Manager_Provider.adoc
+++ b/doc-Managing_Providers/topics/Adding_a_Red_Hat_Virtualization_Manager_Provider.adoc
@@ -3,49 +3,40 @@
 After initial installation and creation of a {product-title} environment, add a Red Hat Virtualization Manager provider to the appliance.
 
 . Navigate to menu:Compute[Infrastructure > Providers].
-. Click  image:1847.png[] (*Configuration*), then click  image:1862.png[] (*Add a New Infrastructure Provider*). 
+. Click  image:1847.png[Configuration] (*Configuration*), then click  image:1862.png[Add a New Infrastructure Provider] (*Add a New Infrastructure Provider*). 
 . Enter a *Name* for the provider.
 . Select *Red Hat Virtualization Manager* from the *Type* list.
 . Select the appropriate *Zone* for the provider. If you do not specify a zone, it is set to *default*.
-. Enter the *Hostname (IPv4 or IPv6)* of the provider.
+. Under *Endpoints* in the *Default* tab, configure the following: 
+* Enter the *Hostname* or IPv4 or IPv6 address of the provider.
 +
 [IMPORTANT]
 ====
 The *Hostname* must be a unique fully qualified domain name.
 ====
-. Enter the *API Port* if your provider uses a non-standard port for access.
-. Select *Yes* or *No* to *Verify TLS Certificates*.
-. To use authenticate the provider using a CA certificate, paste the certificate's text in *Trusted CA Certificates* in PEM format.
-+
-////
-Was:
-. In the *Credentials* area, under *Default*, provide the login credentials required for the Red Hat Virtualization Manager administrative user:
-* Enter the user name, `admin@internal`, in the *Username* field.
-* Enter the password in the *Password* field.
-* Confirm the password in the *Confirm Password* field.
-* Click *Validate* to confirm {product-title} can connect to the Red Hat Virtualization Manager.
-////
-. Enter the credentials for the provider and click *Validate*.
-. In the *C & U Database* tab, configure capacity and utilization metrics collection by providing login credentials for the {product-title} user of the Red Hat Virtualization Data Warehouse database. You can also configure this later by editing the provider.
+* Enter the *API Port* if your provider uses a non-standard port for access.
+* Select *Yes* or *No* to *Verify TLS Certificates*.
+* To use authenticate the provider using a CA certificate, paste the certificate's text in *Trusted CA Certificates* in PEM format.
+* Provide the login credentials required for the Red Hat Virtualization Manager administrative user:
+** Enter the user name (formatted as `admin@internal`) in the *Username* field.
+** Enter the password in the *Password* field.
+** Confirm the password in the *Confirm Password* field.
+** Click *Validate* to confirm {product-title_short} can connect to the Red Hat Virtualization Manager.
+. In the *C & U Database* tab, you can configure capacity and utilization metrics collection by providing login credentials for the {product-title_short} user of the Red Hat Virtualization Data Warehouse database. You can also configure this later by editing the provider.
 +
 [IMPORTANT]
 ====
-The following are required to collect capacity and utilization data from a Red Hat Virtualization provider:
-
-- In {product-title_short}, the capacity and utilization server roles must be enabled. Enable these roles from the settings menu, in menu:Configuration[Server > Server Control]. For more information on capacity and utilization collection, see https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.5-beta/html-single/deployment_planning_guide/#assigning_the_capacity_and_utilization_server_roles[Assigning the Capacity and Utilization Server Roles] in the _Deployment Planning Guide_.
-- In the Red Hat Virtualization environment, the Data Warehouse and Reports components must be installed in that environment, and you must create a {product-title} user in the Data Warehouse database:
-* To install the Data Warehouse and Reports components in a Red Hat Virtualization environment, see the link:https://access.redhat.com/documentation/en/red-hat-virtualization/4.0/paged/installation-guide/[Red Hat Virtualization Installation Guide].
-* To create a {product-title} user in the Data Warehouse database, see https://access.redhat.com/documentation/en/red-hat-cloudforms/4.5/deployment-planning-guide/#data_collection_for_rhev_33_34[Data Collection for Red Hat Enterprise Virtualization 3.3 and 3.4] in the _Deployment Planning Guide_.
+To collect capacity and utilization data from a Red Hat Virtualization provider, the capacity and utilization server roles must be enabled in {product-title_short}. The Red Hat Virtualization environment must also contain the Data Warehouse and Reports components and a {product-title_short} user. See xref:enabling_CU_RHV[] for configuration details.
 ====
 +
-.. Enter the database hostname in the *Hostname* field.
-.. Enter the *API Port* if your provider uses a non-standard port for access.
-.. Enter the *Database Name*.
-.. Enter the database user name in the *Username* field.
-.. Enter the user password in the *Password* field.
-.. Confirm the user password in the *Confirm Password* field.
-.. Click *Validate* to confirm {product-title_short} can connect to the database.
-. Click *Add*.
+* Enter the database hostname or IPv4 or IPv6 address in *Hostname*.
+* Enter the *API Port* if your provider uses a non-standard port for access.
+* Enter the *Database Name*.
+* Enter the database user name in the *Username* field.
+* Enter the user password in the *Password* field.
+* Confirm the user password in the *Confirm Password* field.
+* Click *Validate* to confirm {product-title_short} can connect to the database.
+. Click *Add* to finish adding the Red Hat Virtualization Manager provider.
 
 
 

--- a/doc-Managing_Providers/topics/Adding_a_Red_Hat_Virtualization_Manager_Provider.adoc
+++ b/doc-Managing_Providers/topics/Adding_a_Red_Hat_Virtualization_Manager_Provider.adoc
@@ -4,20 +4,18 @@ After initial installation and creation of a {product-title} environment, add a 
 
 . Navigate to menu:Compute[Infrastructure > Providers].
 . Click  image:1847.png[] (*Configuration*), then click  image:1862.png[] (*Add a New Infrastructure Provider*). 
-. Enter the *Name* of the provider to add.
-  The *Name* is how the device is labeled in the console.
+. Enter a *Name* for the provider.
 . Select *Red Hat Virtualization Manager* from the *Type* list.
-. Select the appropriate *Zone* for the provider.
-  By default, the zone is set to *default*.
-. Enter the *Host Name or IP address(IPv4 or IPv6)* of the provider.
+. Select the appropriate *Zone* for the provider. If you do not specify a zone, it is set to *default*.
+. Enter the *Hostname (IPv4 or IPv6)* of the provider.
 +
 [IMPORTANT]
 ====
-The *Host Name* must use a unique fully qualified domain name.
+The *Hostname* must be a unique fully qualified domain name.
 ====
 . Enter the *API Port* if your provider uses a non-standard port for access.
 . Select *Yes* or *No* to *Verify TLS Certificates*.
-. To use a CA certificate to authenticate the provider, paste the the text of the certificate in *Trusted CA Certificates* in PEM format.
+. To use authenticate the provider using a CA certificate, paste the certificate's text in *Trusted CA Certificates* in PEM format.
 +
 ////
 Was:
@@ -27,35 +25,26 @@ Was:
 * Confirm the password in the *Confirm Password* field.
 * Click *Validate* to confirm {product-title} can connect to the Red Hat Virtualization Manager.
 ////
-. Specify the credentials for the provider and click *Validate*.
-. Under the *C & U Database* tab, configure capacity and utilization metrics collection by providing login credentials for the {product-title} user of the Red Hat Virtualization Data Warehouse database. You can also configure this later by editing the provider.
+. Enter the credentials for the provider and click *Validate*.
+. In the *C & U Database* tab, configure capacity and utilization metrics collection by providing login credentials for the {product-title} user of the Red Hat Virtualization Data Warehouse database. You can also configure this later by editing the provider.
 +
 [IMPORTANT]
 ====
-To collect capacity and utilization data, you must enable the capacity and utilization server roles available from the settings menu, menu:Configuration[Server > Server Control]. For more information on capacity and utilization collection, see https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.5-beta/html-single/deployment_planning_guide/#assigning_the_capacity_and_utilization_server_roles[Assigning the Capacity and Utilization Server Roles] in the _Deployment Planning Guide_.
+The following are required to collect capacity and utilization data from a Red Hat Virtualization provider:
+
+- In {product-title_short}, the capacity and utilization server roles must be enabled. Enable these roles from the settings menu, in menu:Configuration[Server > Server Control]. For more information on capacity and utilization collection, see https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.5-beta/html-single/deployment_planning_guide/#assigning_the_capacity_and_utilization_server_roles[Assigning the Capacity and Utilization Server Roles] in the _Deployment Planning Guide_.
+- In the Red Hat Virtualization environment, the Data Warehouse and Reports components must be installed in that environment, and you must create a {product-title} user in the Data Warehouse database:
+* To install the Data Warehouse and Reports components in a Red Hat Virtualization environment, see the link:https://access.redhat.com/documentation/en/red-hat-virtualization/4.0/paged/installation-guide/[Red Hat Virtualization Installation Guide].
+* To create a {product-title} user in the Data Warehouse database, see https://access.redhat.com/documentation/en/red-hat-cloudforms/4.5/deployment-planning-guide/#data_collection_for_rhev_33_34[Data Collection for Red Hat Enterprise Virtualization 3.3 and 3.4] in the _Deployment Planning Guide_.
 ====
 +
-[IMPORTANT]
-====
-To collect capacity and utilization data for a Red Hat Virtualization environment, the Data Warehouse and Reports components must be installed in that environment, and you must create a {product-title} user in the Data Warehouse database.
-
-// Line break
-
-To install the Data Warehouse and Reports components in a Red Hat Virtualization environment, see the link:https://access.redhat.com/documentation/en/red-hat-virtualization/4.0/paged/installation-guide/[Red Hat Virtualization Installation Guide].
-
-// Line break
-
-ifdef::cfme[To create a {product-title} user in the Data Warehouse database, see https://access.redhat.com/documentation/en/red-hat-cloudforms/4.5/deployment-planning-guide/#data_collection_for_rhev_33_34[Data Collection for Red Hat Enterprise Virtualization 3.3 and 3.4] in the _Deployment Planning Guide_.]
-ifdef::miq[To create a {product-title} user in the Data Warehouse database, see "Data Collection for Red Hat Enterprise Virtualization 3.3 and 3.4" in the _Deployment Planning Guide_.]
-====
-+
-* Enter the database hostname in the *Hostname* field.
-* Enter the *API Port*.
-* Enter the *Database Name*
-* Enter the database user name in the *Username* field.
-* Enter the user password in the *Password* field.
-* Confirm the user password in the *Confirm Password* field.
-* Click *Validate* to confirm {product-title} can connect to the database.
+.. Enter the database hostname in the *Hostname* field.
+.. Enter the *API Port* if your provider uses a non-standard port for access.
+.. Enter the *Database Name*.
+.. Enter the database user name in the *Username* field.
+.. Enter the user password in the *Password* field.
+.. Confirm the user password in the *Confirm Password* field.
+.. Click *Validate* to confirm {product-title_short} can connect to the database.
 . Click *Add*.
 
 

--- a/doc-Managing_Providers/topics/Adding_a_Red_Hat_Virtualization_Manager_Provider.adoc
+++ b/doc-Managing_Providers/topics/Adding_a_Red_Hat_Virtualization_Manager_Provider.adoc
@@ -1,12 +1,12 @@
-= Adding a Red Hat Enterprise Virtualization Manager Provider
+= Adding a Red Hat Virtualization Manager Provider
 
-After initial installation and creation of a {product-title} environment, add a Red Hat Enterprise Virtualization Manager provider to the appliance.
+After initial installation and creation of a {product-title} environment, add a Red Hat Virtualization Manager provider to the appliance.
 
 . Navigate to menu:Compute[Infrastructure > Providers].
 . Click  image:1847.png[] (*Configuration*), then click  image:1862.png[] (*Add a New Infrastructure Provider*). 
 . Enter the *Name* of the provider to add.
   The *Name* is how the device is labeled in the console.
-. Select *Red Hat Enterprise Virtualization Manager* from the *Type* list.
+. Select *Red Hat Virtualization Manager* from the *Type* list.
 . Enter the *Host Name or IP address(IPv4 or IPv6)* of the provider.
 +
 [IMPORTANT]
@@ -16,12 +16,12 @@ The *Host Name* must use a unique fully qualified domain name.
 . Enter the *API Port* if your provider uses a non-standard port for access.
 . Select the appropriate *Zone* for the provider.
   By default, the zone is set to *default*.
-. In the *Credentials* area, under *Default*, provide the login credentials required for the Red Hat Enterprise Virtualization Manager administrative user:
+. In the *Credentials* area, under *Default*, provide the login credentials required for the Red Hat Virtualization Manager administrative user:
 * Enter the user name, `admin@internal`, in the *Username* field.
 * Enter the password in the *Password* field.
 * Confirm the password in the *Confirm Password* field.
-* Click *Validate* to confirm {product-title} can connect to the Red Hat Enterprise Virtualization Manager.
-. Under *C & U Database* tab, provide the login credentials for the {product-title} user of the Red Hat Enterprise Virtualization Data Warehouse database:
+* Click *Validate* to confirm {product-title} can connect to the Red Hat Virtualization Manager.
+. Under *C & U Database* tab, provide the login credentials for the {product-title} user of the Red Hat Virtualization Data Warehouse database:
 +
 [IMPORTANT]
 ====
@@ -30,11 +30,11 @@ To collect capacity and utilization data, you must enable the capacity and utili
 +
 [IMPORTANT]
 ====
-To collect capacity and utilization data for a Red Hat Enterprise Virtualization environment, the Data Warehouse and Reports components must be installed in that environment, and you must create a {product-title} user in the Data Warehouse database.
+To collect capacity and utilization data for a Red Hat Virtualization environment, the Data Warehouse and Reports components must be installed in that environment, and you must create a {product-title} user in the Data Warehouse database.
 
 // Line break
 
-To install the Data Warehouse and Reports components in a Red Hat Enterprise Virtualization environment, see the link:https://access.redhat.com/documentation/en/red-hat-virtualization/4.0/paged/installation-guide/[Red Hat Virtualization Installation Guide].
+To install the Data Warehouse and Reports components in a Red Hat Virtualization environment, see the link:https://access.redhat.com/documentation/en/red-hat-virtualization/4.0/paged/installation-guide/[Red Hat Virtualization Installation Guide].
 
 // Line break
 

--- a/doc-Managing_Providers/topics/Authenticating_Red_Hat_Virtualization_Hosts.adoc
+++ b/doc-Managing_Providers/topics/Authenticating_Red_Hat_Virtualization_Hosts.adoc
@@ -1,4 +1,4 @@
-[[authenticating_rhev_hosts]]
+[[authenticating_rhv_hosts]]
 = Authenticating Red Hat Virtualization Hosts
 
 After adding a Red Hat Virtualization infrastructure provider, you must authenticate its hosts to enable full functionality.

--- a/doc-Managing_Providers/topics/Authenticating_Red_Hat_Virtualization_Hosts.adoc
+++ b/doc-Managing_Providers/topics/Authenticating_Red_Hat_Virtualization_Hosts.adoc
@@ -1,7 +1,7 @@
 [[authenticating_rhev_hosts]]
-= Authenticating Red Hat Enterprise Virtualization Hosts
+= Authenticating Red Hat Virtualization Hosts
 
-After adding a Red Hat Enterprise Virtualization infrastructure provider, you must authenticate its hosts to enable full functionality.
+After adding a Red Hat Virtualization infrastructure provider, you must authenticate its hosts to enable full functionality.
 
 . Navigate to menu:Compute[Infrastructure > Providers].
 . Click on a provider to display its summary screen.
@@ -13,7 +13,7 @@ After adding a Red Hat Enterprise Virtualization infrastructure provider, you mu
 . In the *Credentials* area, enter credentials for the following, as required:
  .. *Default*: This field is mandatory. Users should have privileged access such as, root or administrator. 
  .. *Remote Login*: Credentials for this field are required if SSH login is disabled for the *Default* account.
- .. *Web Services*: This tab is used for access to Web Services in Red Hat Enterprise Virtualization Manager.
+ .. *Web Services*: This tab is used for access to Web Services in Red Hat Virtualization Manager.
  .. *IPMI*:  This tab is used for access to IPMI.
 . Click *Validate*.
 . If editing multiple hosts:

--- a/doc-Managing_Providers/topics/Enabling_Red_Hat_Virtualization_CU.adoc
+++ b/doc-Managing_Providers/topics/Enabling_Red_Hat_Virtualization_CU.adoc
@@ -1,0 +1,12 @@
+[[enabling_CU_RHV]]
+= Enabling Red Hat Virtualization Capacity and Utilization Data Collection
+
+Configure the following to collect capacity and utilization data from a Red Hat Virtualization Manager provider:
+
+* In {product-title_short}, enable the capacity and utilization server roles from the settings menu, in menu:Configuration[Server > Server Control]. For more information on capacity and utilization collection, see https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.5-beta/html-single/deployment_planning_guide/#assigning_the_capacity_and_utilization_server_roles[Assigning the Capacity and Utilization Server Roles] in the _Deployment Planning Guide_.
+
+//https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.5-beta/html-single/deployment_planning_guide/#assigning_the_capacity_and_utilization_server_roles[Assigning the Capacity and Utilization Server Roles]
+
+* In your Red Hat Virtualization environment, install the Data Warehouse and Reports components, and create a {product-title} user in the Data Warehouse database:
+** To install the Data Warehouse and Reports components in a Red Hat Virtualization environment, see the link:https://access.redhat.com/documentation/en/red-hat-virtualization/4.0/paged/installation-guide/[Red Hat Virtualization Installation Guide].
+** To create a {product-title_short} user in the Data Warehouse database, see https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.5-beta/html-single/deployment_planning_guide/#data_collection_for_rhev_33_34[Data Collection for Red Hat Enterprise Virtualization] in the _Deployment Planning Guide_.

--- a/doc-Managing_Providers/topics/Infrastructure_Providers.adoc
+++ b/doc-Managing_Providers/topics/Infrastructure_Providers.adoc
@@ -74,7 +74,10 @@ include::Discovering_Multiple_Management_Systems.adoc[]
 :leveloffset: 2
 = Red Hat Virtualization Manager Providers
 
-To use a Red Hat Virtualization Manager provider, add it to the appliance and authenticate its hosts.
+To use a Red Hat Virtualization Manager provider, add it to the appliance and authenticate its hosts. You can also configure capacity and utilization data collection to help track usage and find common issues.
+
+:leveloffset: 3
+include::Enabling_Red_Hat_Virtualization_CU.adoc[]
 
 :leveloffset: 3
 include::Adding_a_Red_Hat_Virtualization_Manager_Provider.adoc[]

--- a/doc-Managing_Providers/topics/Infrastructure_Providers.adoc
+++ b/doc-Managing_Providers/topics/Infrastructure_Providers.adoc
@@ -72,16 +72,16 @@ image:2192.png[]
 include::Discovering_Multiple_Management_Systems.adoc[]
 
 :leveloffset: 2
-= Red Hat Enterprise Virtualization Manager Providers
+= Red Hat Virtualization Manager Providers
 
-To use a Red Hat Enterprise Virtualization Manager provider, add it to the appliance and authenticate its hosts.
-
-:leveloffset: 3
-include::Adding_a_Red_Hat_Enterprise_Virtualization_Manager_Provider.adoc[]
-
+To use a Red Hat Virtualization Manager provider, add it to the appliance and authenticate its hosts.
 
 :leveloffset: 3
-include::Authenticating_Red_Hat_Enterprise_Virtualization_Hosts.adoc[]
+include::Adding_a_Red_Hat_Virtualization_Manager_Provider.adoc[]
+
+
+:leveloffset: 3
+include::Authenticating_Red_Hat_Virtualization_Hosts.adoc[]
 
 :leveloffset: 2
 = OpenStack Infrastructure Providers

--- a/doc-Managing_Providers/topics/Managing_Containers.adoc
+++ b/doc-Managing_Providers/topics/Managing_Containers.adoc
@@ -1,6 +1,6 @@
 = The Container Overview Page
 
-Navigate to menu:Compute[Containers > <Object>] to view information on many different container objects. 
+Navigate to menu:Compute[Containers > _Object_] to view information on many different container objects. 
 
 [[cross-providers-insight]]
 == Cross-Providers Insight
@@ -10,7 +10,7 @@ Cross-providers insight is a feature that connects all layers of infrastructure,
 It supports cross-linking all of the layers available in the following environments:
 
 * OpenStack
-* Red Hat Enterprise Virtualization
+* Red Hat Virtualization
 * VMware vCenter
 * Amazon EC2
 * Google Cloud Engine


### PR DESCRIPTION
Hi Suyog,

As discussed in today's docs meeting, this content should make it into beta, so let's go ahead with the peer review/merge process for now, and if there is engineering feedback on it later, I will correct it post-beta.

Could you please review and provide any feedback/corrections on the following:

http://file.bne.redhat.com/~dayparke/CloudForms/AddRHVprovider2/build/tmp/en-US/html-single/#adding_a_red_hat_virtualization_manager_provider

- I've made all of the changes Andrew mentioned above, and a few additional ones while testing the procedure, like dividing the config steps by tab in the UI (Default/C&U Database).
- I ended up creating a new section on enabling metrics ("1.2.1. Enabling Red Hat Virtualization Capacity and Utilization Data Collection"), for 2 reasons - the Important box(es) were getting pretty giant in step 9 [1]; and while I was working on a similar procedure for OpenShift, I noticed there was a separate metrics config section which looked quite good, so why not clarify and keep it consistent :) [2]

Please let me know what you think!

Cheers,
Dayle

[1] https://doc-stage.usersys.redhat.com/documentation/en-us/red_hat_cloudforms/4.5-beta/html-single/managing_providers/#adding_a_red_hat_enterprise_virtualization_manager_provider

[2] https://doc-stage.usersys.redhat.com/documentation/en-us/red_hat_cloudforms/4.5-beta/html-single/managing_providers/#enabling_openshift_cluster_metrics