### PR TITLE
Testing - re-add green triangle image

### DIFF
--- a/doc-Installing_on_Red_Hat_Virtualization/topics/installation.adoc
+++ b/doc-Installing_on_Red_Hat_Virtualization/topics/installation.adoc
@@ -196,6 +196,6 @@ The virtual machine is created. To view the virtual machine, select the data cen
 .. Set the *Allocation Policy* to `Preallocated` (thick provisioning) for best performance.
 .. Specify any other values as desired.
 .. Click *OK* to create the disk.
-. To start the {product-title} appliance, select the virtual machine from the *Virtual Machines* tab and click image:greentriangle.png[] (*Run*). 
+. To start the {product-title} appliance, select the virtual machine from the *Virtual Machines* tab and click  image:greentriangle.png[] (*Run*). 
 
 Your Red Hat Virtualization environment now contains a running {product-title} appliance.


### PR DESCRIPTION
The green triangle image for "run" in RHV is not building in the 4.2 Installing on RHV guide. Just attempting a re-add/push in case it fixes things.

Originally all the work was done in https://bugzilla.redhat.com/show_bug.cgi?id=1411114.
