### PR TITLE
add note about enabling and verifying Ansible role

### DIFF
--- a/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
+++ b/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
@@ -1,30 +1,42 @@
 [[automation_management_providers]]
 = Automation Management Providers
 
+[NOTE]
+====
+{product-title} ships with the Ansible role disabled. Navigate to menu:settings menu[Configuration > Settings] and select the desired server under *Zones*. Set the *Server Role* for *Embedded Ansible* to *On* to enable the role.
+====
 
 [[ansible-inside]]
 == Ansible
 
-Ansible integrates with {product-title} to provide automation solutions, using Playbooks, for Service, Policy and Alert actions. 
-Ansible Playbooks consist of series of _plays_ or tasks that define automation across a set of hosts,
+Ansible integrates with {product-title} to provide automation solutions, using playbooks, for Service, Policy and Alert actions. 
+Ansible playbooks consist of series of _plays_ or tasks that define automation across a set of hosts,
 known as the inventory. 
 
-Ranging from simple to complex tasks, Ansible Playbooks can support cloud management:
+Ranging from simple to complex tasks, Ansible playbooks can support cloud management:
 
-* *Services* - allow a Playbook to back a {product-title_short} service catalog item.
-* *Control Actions* - {product-title_short} policies can execute Playbooks as actions based on events from providers.
-* *Control Alerts* - set a Playbook to launch prompted by a {product-title_short} alert.
+* *Services* - allow a playbook to back a {product-title_short} service catalog item.
+* *Control Actions* - {product-title_short} policies can execute playbooks as actions based on events from providers.
+* *Control Alerts* - set a playbook to launch prompted by a {product-title_short} alert.
 
 Ansible is built into {product-title_short} so there is nothing to install. The basic workflow when using Ansible in {product-title} is as follows:
 
-* Add a source control repository that contains your Playbooks.
+* Add a source control repository that contains your playbooks.
 * Establish credentials with your inventory. 
-* Back your services, alerts and policies using available Playbooks. 
+* Back your services, alerts and policies using available playbooks. 
 
+[[verifying-embedded-ansible-worker-state]]
+=== Verifying the Embedded Ansible Worker State
+Verify that the Embedded Ansible worker has started to utilize its features. 
+
+. Navigate to menu:settings menu[Configuration > Diagnostics] and click on the desired server.
+. Click on the *Workers* tab. 
+
+A table of all workers and current status will appear from which you can confirm the state of your Embedded Ansible worker. 
 
 [[adding-a-playbook-repository]]
 === Adding a Playbook Repository
-Add a repository so that {product-title} can discover and make available your Playbooks.
+Add a repository so that {product-title} can discover and make available your playbooks.
  
 . Navigate to menu:Automation[Ansible > Repositories].
 . Click *Add*.
@@ -37,10 +49,11 @@ Add a repository so that {product-title} can discover and make available your Pl
 . Check the appropriate box for any *SCM Update Options*.
 . Click *Add*.
 
-Once you have synced a repository, its Playbooks will become available to {product-title_short}.  
+Once you have synced a repository, its playbooks will become available to {product-title_short}.  
 
 [[adding-credentials]]
 === Adding Credentials
+{product-title} can store credentials used by playbooks. Credentials saved in {product-title_short} are matched and executed with a playbook when run.   
 
 . Navigate to menu:Automation[Ansible > Credentials].
 . Click  image:1847.png[Configuration] (*Configuration*), then  image:1862.png[Add a New Credential] (*Add a New Credential*).

--- a/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
+++ b/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
@@ -32,7 +32,7 @@ Verify that the embedded Ansible worker has started to utilize its features.
 . Navigate to the settings menu, then *Configuration* &#8594; *Diagnostics* and click on the desired server.
 . Click on the *Workers* tab. 
 
-A table of all workers and current status will appear from which you can confirm the state of your Embedded Ansible worker. 
+A table of all workers and current status will appear from which you can confirm the state of your embedded Ansible worker. 
 
 [[adding-a-playbook-repository]]
 === Adding a Playbook Repository

--- a/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
+++ b/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
@@ -3,7 +3,7 @@
 
 [NOTE]
 ====
-{product-title} ships with the Ansible role disabled. Navigate to menu:settings menu[Configuration > Settings] and select the desired server under *Zones*. Set the *Server Role* for *Embedded Ansible* to *On* to enable the role.
+In {product-title},the Ansible role is disabled by default. Navigate to the settings menu, then *Configuration* &#8594; *Settings* and select the desired server under *Zones*. Set the *Server Role* for *Embedded Ansible* to *On* to enable the role.
 ====
 
 [[ansible-inside]]
@@ -27,9 +27,9 @@ Ansible is built into {product-title_short} so there is nothing to install. The 
 
 [[verifying-embedded-ansible-worker-state]]
 === Verifying the Embedded Ansible Worker State
-Verify that the Embedded Ansible worker has started to utilize its features. 
+Verify that the embedded Ansible worker has started to utilize its features. 
 
-. Navigate to menu:settings menu[Configuration > Diagnostics] and click on the desired server.
+. Navigate to the settings menu, then *Configuration* &#8594; *Diagnostics* and click on the desired server.
 . Click on the *Workers* tab. 
 
 A table of all workers and current status will appear from which you can confirm the state of your Embedded Ansible worker. 


### PR DESCRIPTION
Hey Suyog,

I've added a note about enabling the Ansible role and verifying status of the worker. While I was in the file I also took the opportunity to make some corrections, ie, lower-case for playbooks. 

You can find a preview of the changes here:

http://file.rdu.redhat.com/~cbudzilo/CloudForms/ansible-note/build/tmp/en-US/html-single/#automation_management_providers

Please let me know what you think. 

-Chris