### PR TITLE
remove info about deleting default zone

### DIFF
--- a/doc-General_Configuration/topics/Configuration.adoc
+++ b/doc-General_Configuration/topics/Configuration.adoc
@@ -524,7 +524,7 @@ If Appliance A dispatches a job of analyzing twenty virtual machines, this job c
 
 [NOTE]
 ======
-Only users assigned the super administrator role can create zones. There must always be at least one zone. Default zone is provided. This can be removed only after you have created your own zones.
+Only users assigned the super administrator role can create zones. There must always be at least one zone. The *Default Zone* is provided and cannot be deleted. 
 ======
 
 [[creating-a-zone]]


### PR DESCRIPTION
Hey Suyog,

I've updated the General Configuration doc to specify that the Default Zone cannot be deleted, per [BZ1441819](https://bugzilla.redhat.com/show_bug.cgi?id=1441819). PLease find a preview of the doc here:

http://file.rdu.redhat.com/~cbudzilo/CloudForms/default-zone/build/tmp/en-US/html-single/#zones

Please let me know what you think. 