### PR TITLE
added two new container roles to groups table

### DIFF
--- a/doc-General_Configuration/topics/Configuration.adoc
+++ b/doc-General_Configuration/topics/Configuration.adoc
@@ -954,17 +954,20 @@ This group must be in the LDAP directory source you specified for the server. Se
 |EvmGroup-administrator|Administrator
 |EvmGroup-approver|Approver
 |EvmGroup-auditor|Auditor
+|EvmGroup-consumption_administrator|Consumption Administrator
+|EvmGroup-container_administrator|Container Administrator
+|EvmGroup-container_operator|Container Operator
 |EvmGroup-desktop|Desktop
 |EvmGroup-operator|Operator
 |EvmGroup-security|Security
 |EvmGroup-super_administrator|Super Administrator
 |EvmGroup-support|Support
-|EvmGroup-user|User
-|EvmGroup-user_limited_self_server|User Limited Self Service
-|EvmGroup-user_self_service|User Self Service
-|EvmGroup-vm_user|Vm User
 |EvmRole-tenant_administrator|Tenant Administrator
 |EvmRole-tenant_quota_administrator|Tenant Quota Administrator
+|EvmGroup-user|User
+|EvmGroup-user_limited_self_service|User Limited Self Service
+|EvmGroup-user_self_service|User Self Service
+|EvmGroup-vm_user|Vm User
 |=======================================================================
 +
 . Make each user of your directory service that you want to have access to {product-title} a member of one of these groups.


### PR DESCRIPTION
Hi Chris,

I've added the two new container management roles to the General Config guide table which contains the other roles. Could you please review the changes?

I also fixed a typo ( s/server/service) and noticed we hadn't included Consumption Administrator in the docs yet, so added that role too. I realize we still need a description of this, so have created a new bug as it will require more digging and is a bit out of scope for this bug - https://bugzilla.redhat.com/show_bug.cgi?id=1448784.

If you want to check out the list of roles (I had to dig through our docs to remember how), go to the settings menu > Configuration > Access Control dropdown side menu > expand Groups.

Preview here (ctrl+F section "4.1.4.2.6. Using Groups Named by Red Hat CloudForms to Assign Account Roles"): 
http://file.bne.redhat.com/~dayparke/CloudForms/container-roles/build/tmp/en-US/html-single/

Please let me know if you have any feedback. I checked the Release Notes and luckily we've already mentioned the roles there too.

Cheers,
Dayle

