### PR TITLE
[WIP] Bz#1448479 HA restore DB

### DIFF
--- a/doc-General_Configuration/topics/Configuration.adoc
+++ b/doc-General_Configuration/topics/Configuration.adoc
@@ -2953,7 +2953,7 @@ To restore a database from a backup:
 . Press `Y` to confirm.
 . After the backup completes, press *Enter* to return to the menu.
 . Press *Enter* again to manually configure settings.
-. Select `Start EVM Server Processes` to restart all processes on servers that connect to this VMDB..
+. Select `Start EVM Server Processes` to restart all processes on servers that connect to this VMDB.
 . Enter `Y` to confirm.
 . Start the `regmgrd` service: 
 +

--- a/doc-General_Configuration/topics/Configuration.adoc
+++ b/doc-General_Configuration/topics/Configuration.adoc
@@ -2927,11 +2927,11 @@ To run a single database backup:
 [[restoring-a-database-from-a-backup]]
 ===== Restoring a Database from a Backup
 
-If a database is corrupt or fails, restore it from a backup.
+If a database is corrupt or fails, restore it from a backup. You can restore a backup from a local file, NFS, or Samba.
 
 To restore a database from a backup:
 
-. Save the database backup file as `/tmp/evm_db.backup`. {product-title} looks specifically for this file when restoring a database from a backup.
+. Save the database backup file as `/tmp/evm_db.backup`. {product-title} looks specifically for this file when restoring a database from a local backup.
 . If you are restoring a database backup on a high availability environment, stop the `regmgrd` service. This is not required in other {product-title_short} configurations.
 +
 ----
@@ -2944,8 +2944,16 @@ To restore a database from a backup:
 . Enter `Y` to confirm.
 . After all processes are stopped, press *Enter* to return to the menu.
 . Press *Enter* again to manually configure settings.
-. Select `Restore Database From Backup`. If connections are open, the server may still be shutting down. Wait a minute and try again.
-. Enter `y` to keep the database backup after restoring from it. Enter `n` to delete it.
+. Select `Restore Database From Backup`, then specify the location to restore the backup from in the `Restore Database File` menu:
+.. If you saved the database backup file locally as `/tmp/evm_db.backup`, select `Local file`. You can also restore from a `Network File System (nfs)` or `Samba (smb)`.
+.. Specify the location of the backup file.
++
+[NOTE]
+====
+The appliance console menu may respond slowly if connections are open and the server is still shutting down. If this occurs, wait a minute and try again.
+====
++
+. Enter `Y` to keep the database backup after restoring from it. Enter `N` to delete it.
 . Press `Y` to confirm.
 . After the backup completes, press *Enter* to return to the menu.
 . Press *Enter* again to manually configure settings.

--- a/doc-General_Configuration/topics/Configuration.adoc
+++ b/doc-General_Configuration/topics/Configuration.adoc
@@ -2724,15 +2724,15 @@ Performing this procedure destroys any existing data and cannot be undone. Back 
 . Log in to the appliance as the *root* user.
 . Enter `appliance_console`, and press *Enter*.
 . Press any key.
-. Enter `16` to stop EVM server processes.
+. Select `Stop EVM Server Processes`.
 . Enter `Y` to confirm.
-. Choose *Configure Database*.
+. Choose `Configure Database`.
 . Enter a database region number that has not been used in your environment. Do not enter duplicate region numbers because this can corrupt the data.
 . Enter `Y` to confirm.
 . The menu reappears after all processes are complete.
-. Enter `17` to start EVM server processes.
+. Select `Start EVM Server Processes`.
 . Enter `Y` to confirm.
-. Enter `21` to quit the advanced settings menu.
+. Select *Quit* to exit the advanced settings menu.
 
 [[configuring_database_replication]]
 ==== Configuring Database Replication and Centralized Administration
@@ -2936,19 +2936,31 @@ If a database is corrupt or fails, restore it from a backup.
 To restore a database from a backup:
 
 . Save the database backup file as `/tmp/evm_db.backup`. {product-title} looks specifically for this file when restoring a database from a backup.
-. Log in to the appliance console with a user name of `admin` and the default password. The *Appliance Summary Screen* displays.
+. Stop the `regmgrd` service: 
++
+----
+# systemctl stop rh-postgresql95-repmgr
+----
++
+. Log in to the appliance console with a user name of `admin` and the default password. The appliance summary screen displays.
 . Press *Enter* to manually configure settings.
-. Enter `11` to `Stop Server Processes`. Stop the process on all servers that connect to this VMDB.
+. Select `Stop EVM Server Processes` to stop processes on all servers that connect to this VMDB.
 . Enter `Y` to confirm.
 . After all processes are stopped, press *Enter* to return to the menu.
 . Press *Enter* again to manually configure settings.
-. Enter `6` to select `Restore Database From Backup`. If connections are open, the server may still be shutting down. Wait a minute and try again.
+. Select `Restore Database From Backup`. If connections are open, the server may still be shutting down. Wait a minute and try again.
 . Enter `y` to keep the database backup after restoring from it. Enter `n` to delete it.
 . Press `Y` to confirm.
 . After the backup completes, press *Enter* to return to the menu.
 . Press *Enter* again to manually configure settings.
-. Enter `13` to `Start Server Processes`.
+. Select `Start EVM Server Processes` to restart all processes on servers that connect to this VMDB..
 . Enter `Y` to confirm.
+. Start the `regmgrd` service: 
++
+----
+# systemctl start rh-postgresql95-repmgr
+----
+
 
 [[running-database-garbage-collection]]
 ==== Running Database Garbage Collection

--- a/doc-General_Configuration/topics/Configuration.adoc
+++ b/doc-General_Configuration/topics/Configuration.adoc
@@ -2769,12 +2769,8 @@ Configure a {product-title} instance to act as a remote copy from which data wil
 
 Configure a {product-title} instance to act as the global copy to which data is replicated from the remote copies.
 
-image:add-subscription.png[Add Subscription]
-
-. Navigate to the settings menu.
-. Click *Configuration*.
-. Click the *Settings* accordion.
-. Click the region where the instance is located.
+image:add-subscription.png[Add Subscription]. Log in to the appliance as the *root* user.
+. Enter `appliance_console`, and press *Enter*.
 . Click *Replication*.
 . Select *Global* from the *Type* list.
 . Click *Add Subscription*.
@@ -2936,14 +2932,14 @@ If a database is corrupt or fails, restore it from a backup.
 To restore a database from a backup:
 
 . Save the database backup file as `/tmp/evm_db.backup`. {product-title} looks specifically for this file when restoring a database from a backup.
-. Stop the `regmgrd` service: 
+. If you are restoring a database backup on a high availability environment, stop the `regmgrd` service. This is not required in other {product-title_short} configurations.
 +
 ----
 # systemctl stop rh-postgresql95-repmgr
 ----
 +
-. Log in to the appliance console with a user name of `admin` and the default password. The appliance summary screen displays.
-. Press *Enter* to manually configure settings.
+. Log in to the appliance as the *root* user.
+. Enter `appliance_console`, and press *Enter*.
 . Select `Stop EVM Server Processes` to stop processes on all servers that connect to this VMDB.
 . Enter `Y` to confirm.
 . After all processes are stopped, press *Enter* to return to the menu.
@@ -2955,7 +2951,7 @@ To restore a database from a backup:
 . Press *Enter* again to manually configure settings.
 . Select `Start EVM Server Processes` to restart all processes on servers that connect to this VMDB.
 . Enter `Y` to confirm.
-. Start the `regmgrd` service: 
+. If you are restoring a database backup on a high availability environment, start the `regmgrd` service. This is not required in other {product-title_short} configurations.
 +
 ----
 # systemctl start rh-postgresql95-repmgr

--- a/doc-General_Configuration/topics/Configuration.adoc
+++ b/doc-General_Configuration/topics/Configuration.adoc
@@ -2769,7 +2769,9 @@ Configure a {product-title} instance to act as a remote copy from which data wil
 
 Configure a {product-title} instance to act as the global copy to which data is replicated from the remote copies.
 
-image:add-subscription.png[Add Subscription]. Log in to the appliance as the *root* user.
+image:add-subscription.png[Add Subscription]
+
+. Log in to the appliance as the *root* user.
 . Enter `appliance_console`, and press *Enter*.
 . Click *Replication*.
 . Select *Global* from the *Type* list.


### PR DESCRIPTION
WIP PR for review.

Fixes for https://bugzilla.redhat.com/show_bug.cgi?id=1448479
* General Config Guide - 4.4.4.2. Restoring a Database from a Backup
--> Add a step before the current step 2 ("Log in to the appliance console ...") to stop regmgrd service: `systemctl stop rh-postgresql95-repmgr`

--> Add a step to start repmgrd services at the end of "4.4.4.2. Restoring a Database from a Backup": `systemctl start rh-postgresql95-repmgr`

--> Remove all appliance console menu numbers, as these change all the time (I think we'd agreed on this direction a while ago but maybe this section was missed).