### PR TITLE
Added section for CloudForms (only) to apply minor updates in HA environment

### DIFF
--- a/doc-Configuring_High_Availability/cfme/master.adoc
+++ b/doc-Configuring_High_Availability/cfme/master.adoc
@@ -17,6 +17,8 @@ include::common/attributes/cfme.adoc[]
 include::topics/Overview.adoc[]
 include::topics/Installation.adoc[]
 include::topics/Database_Failover.adoc[]
+//Updating_HA is only in CFME as it's concerning subscriptions.
+include::topics/Updating_HA.adoc[]
 
 
 

--- a/doc-Configuring_High_Availability/topics/Updating_HA.adoc
+++ b/doc-Configuring_High_Availability/topics/Updating_HA.adoc
@@ -1,10 +1,15 @@
 [[updating-ha]]
 == Applying Updates in a High Availability Environment
 
-Applying minor updates and errata to appliances in a high availability environment must be performed in a specific order to avoid a database migration (to the next major version?).
+Applying minor updates and errata to appliances in a high availability environment must be performed in a specific order to avoid migrating your databases to the next major {product-title_short} version.
 
 //////
 Later, link to migrating a HA environment in the migration guide.
+
+IMPORTANT
+This procedure details applying minor updates (errata, z-stream) to CloudForms appliances.
+For instructions on migrating between major CloudForms releases, see [ADD LINK TO “1.5. Migrating High Availability Environments from CFME 5.7 to 5.8”, added in https://bugzilla.redhat.com/show_bug.cgi?id=1448775]
+
 //////
 
 .Prerequisites
@@ -32,8 +37,6 @@ Follow this procedure to update the environment with platform updates, but witho
 . Power off the {product-title_short} appliances.
 . Power off the database-only (VMDB) appliances.
 . Back up each appliance:
-// Q: Same as in 1.2 Back Up Current Appliances, steps 1-3?
-// https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.2/html/migrating_to_red_hat_cloudforms_4.2/index#back_up_current_appliances Same method for non-DB and database-only appliances? 
 .. Back up the database of your appliance. Take a snapshot if possible.
 .. Back up the following files for disaster recovery, noting which appliance each comes from:
   * `/var/www/miq/vmdb/GUID`
@@ -51,24 +54,14 @@ Follow this procedure to update the environment with platform updates, but witho
 This step is not required on the database-only appliances, as `evmserverd` does not run on them.
 ====
 +
-. Apply updates to each appliance by running: 
-//(Q: Is there an order to which appliances you update first?) On each appliance, run:
+. Apply updates by running the following on each appliance: 
 +
 ------
 # yum update
 ------
 +
-//Q: Where does the below step go?
-. On one of the {product-title_short} (non-database) appliances, apply any database migration updates and reset the Red Hat and ManageIQ automation domains:
-+
-------
-# vmdb
-# rake db:migrate
-# rake evm:automate:reset
-------
-+
 . Power off the {product-title_short} appliances. 
-. Reboot the databases (database appliances?).
+. Reboot the database-only appliances.
 . Wait five minutes, then start the {product-title_short} appliances again.
 
 The appliances in your high availability environment are now up to date.

--- a/doc-Configuring_High_Availability/topics/Updating_HA.adoc
+++ b/doc-Configuring_High_Availability/topics/Updating_HA.adoc
@@ -1,9 +1,10 @@
 [[updating-ha]]
 == Applying Updates in a High Availability Environment
 
-Applying minor updates and errata to appliances in a high availability environment must be performed in a specific order to avoid migrating your databases to the next major {product-title_short} version.
+Applying software package minor updates (referred to as _errata_) to appliances in a high availability environment must be performed in a specific order to avoid migrating your databases to the next major {product-title_short} version.
 
 //////
+Errata definition from https://access.redhat.com/documentation/en-US/Red_Hat_Satellite/6.1/html/User_Guide/chap-Red_Hat_Satellite-User_Guide-Viewing_and_Applying_Errata.html
 Later, link to migrating a HA environment in the migration guide.
 
 IMPORTANT
@@ -14,7 +15,7 @@ For instructions on migrating between major CloudForms releases, see [ADD LINK T
 
 .Prerequisites
 
-Ensure each appliance is registered to Red Hat Subscription Manager in order to access updates.
+Ensure each appliance is registered to Red Hat Subscription Manager and subscribed to the update channels required by {product-title_short} in order to access updates.
 
 To verify if your appliance is registered and subscribed to the correct update channels, run:
 //Test on an appliance to see what the output looks like.
@@ -24,25 +25,25 @@ To verify if your appliance is registered and subscribed to the correct update c
 
 Appliances must be subscribed to the following channels:
 
-* `cf-me-5.7-for-rhel-7-rpms`
+* `cf-me-5.8-for-rhel-7-rpms`
 * `rhel-7-server-rpms`
 * `rhel-server-rhscl-7-rpms`
 
-If any appliance shows it is not registered or is missing a subscription to any of these channels, see _Registering and Updating {product-title}_ in https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.2/html-single/general_configuration/[General Configuration] to register the appliance.
+If any appliance shows it is not registered or is missing a subscription to any of these channels, see _Registering and Updating {product-title}_ in https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.5/html-single/general_configuration/[General Configuration] to register and subscribe the appliance.
 
 .Updating the Appliances
 
-Follow this procedure to update the environment with platform updates, but without performing a database migration:
+Follow this procedure to update appliances in your environment without migrating the database to the next major version of {product-title_short}. Note the appliance to perform each step on: some steps are to be performed only on the database-only appliances, and other steps only on the {product-title_short} appliances, while some steps apply to all appliances.
 
 . Power off the {product-title_short} appliances.
-. Power off the database-only (VMDB) appliances.
+. Power off the database-only appliances.
 . Back up each appliance:
 .. Back up the database of your appliance. Take a snapshot if possible.
 .. Back up the following files for disaster recovery, noting which appliance each comes from:
   * `/var/www/miq/vmdb/GUID`
   * `/var/www/miq/vmdb/REGION`
 .. Note the hostnames and IP addresses of each appliance. This information is available on the summary screen of the appliance console.
-. Start each database-only (VMDB) appliance.
+. Start each database-only appliance.
 . Start each {product-title_short} appliance again, and stop `evmserverd` on each just after boot:
 +
 ------

--- a/doc-Configuring_High_Availability/topics/Updating_HA.adoc
+++ b/doc-Configuring_High_Availability/topics/Updating_HA.adoc
@@ -1,0 +1,75 @@
+[[updating-ha]]
+== Applying Updates in a High Availability Environment
+
+Applying minor updates and errata to appliances in a high availability environment must be performed in a specific order to avoid a database migration (to the next major version?).
+
+//////
+Later, link to migrating a HA environment in the migration guide.
+//////
+
+.Prerequisites
+
+Ensure each appliance is registered to Red Hat Subscription Manager in order to access updates.
+
+To verify if your appliance is registered and subscribed to the correct update channels, run:
+//Test on an appliance to see what the output looks like.
+----
+# yum repolist
+----
+
+Appliances must be subscribed to the following channels:
+
+* `cf-me-5.7-for-rhel-7-rpms`
+* `rhel-7-server-rpms`
+* `rhel-server-rhscl-7-rpms`
+
+If any appliance shows it is not registered or is missing a subscription to any of these channels, see _Registering and Updating {product-title}_ in https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.2/html-single/general_configuration/[General Configuration] to register the appliance.
+
+.Updating the Appliances
+
+Follow this procedure to update the environment with platform updates, but without performing a database migration:
+
+. Power off the {product-title_short} appliances.
+. Power off the database-only (VMDB) appliances.
+. Back up each appliance:
+// Q: Same as in 1.2 Back Up Current Appliances, steps 1-3?
+// https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.2/html/migrating_to_red_hat_cloudforms_4.2/index#back_up_current_appliances Same method for non-DB and database-only appliances? 
+.. Back up the database of your appliance. Take a snapshot if possible.
+.. Back up the following files for disaster recovery, noting which appliance each comes from:
+  * `/var/www/miq/vmdb/GUID`
+  * `/var/www/miq/vmdb/REGION`
+.. Note the hostnames and IP addresses of each appliance. This information is available on the summary screen of the appliance console.
+. Start each database-only (VMDB) appliance.
+. Start each {product-title_short} appliance again, and stop `evmserverd` on each just after boot:
++
+------
+# systemctl stop evmserverd
+------
++
+[NOTE]
+====
+This step is not required on the database-only appliances, as `evmserverd` does not run on them.
+====
++
+. Apply updates to each appliance by running: 
+//(Q: Is there an order to which appliances you update first?) On each appliance, run:
++
+------
+# yum update
+------
++
+//Q: Where does the below step go?
+. On one of the {product-title_short} (non-database) appliances, apply any database migration updates and reset the Red Hat and ManageIQ automation domains:
++
+------
+# vmdb
+# rake db:migrate
+# rake evm:automate:reset
+------
++
+. Power off the {product-title_short} appliances. 
+. Reboot the databases (database appliances?).
+. Wait five minutes, then start the {product-title_short} appliances again.
+
+The appliances in your high availability environment are now up to date.
+


### PR DESCRIPTION
Created a new section for the HA guide on applying minor updates/errata to appliances in an HA setup.

A few questions:

* When we say "to avoid a database migration", is the 'migration' referring to a major release migration (ie. CFME 5.7 > 5.8?)
* Step 3 borrows some of the backup steps from "1.2. Back Up Current Appliances" in https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.2/html-single/migrating_to_red_hat_cloudforms_4.2/#back_up_current_appliances. Is that correct?
* Step 6 - should 'yum update' be performed on the appliances in a certain order?
* Step 7 - Which appliance does this apply to (ie. the primary database-only appliance?)

Notes:
* Once finished, I'll also link here to the 'migrating a HA environment' steps that are WIP for the Migration Guide.
* I have only produced this procedure for CloudForms -- would there be equivalent update steps for MIQ? (maybe a FutureFeature BZ)

Please let me know if you spot anything needing corrections/clarifications.
Cheers,
Dayle