### PR TITLE
[EUWE] Added new section on updating CF HA environment with minor updates

### DIFF
--- a/doc-Configuring_High_Availability/cfme/master.adoc
+++ b/doc-Configuring_High_Availability/cfme/master.adoc
@@ -17,7 +17,8 @@ include::common/attributes/cfme.adoc[]
 include::topics/Overview.adoc[]
 include::topics/Installation.adoc[]
 include::topics/Database_Failover.adoc[]
-
+//Updating_HA is only in CFME as it's concerning subscriptions.
+include::topics/Updating_HA.adoc[]
 
 
 

--- a/doc-Configuring_High_Availability/topics/Updating_HA.adoc
+++ b/doc-Configuring_High_Availability/topics/Updating_HA.adoc
@@ -1,0 +1,67 @@
+[[updating-ha]]
+== Applying Updates in a High Availability Environment
+
+Applying software package minor updates (referred to as _errata_) to appliances in a high availability environment must be performed in a specific order to avoid migrating your databases to the next major {product-title_short} version.
+
+//////
+Errata definition from https://access.redhat.com/documentation/en-US/Red_Hat_Satellite/6.1/html/User_Guide/chap-Red_Hat_Satellite-User_Guide-Viewing_and_Applying_Errata.html
+Later, link to migrating a HA environment in the migration guide.
+
+As it's 5.7/4.2, no need for ADD LINK TO “1.5. Migrating High Availability Environments from CFME 5.7 to 5.8”, added in https://bugzilla.redhat.com/show_bug.cgi?id=1448775]
+
+//////
+
+.Prerequisites
+
+Ensure each appliance is registered to Red Hat Subscription Manager and subscribed to the update channels required by {product-title_short} in order to access updates.
+
+To verify if your appliance is registered and subscribed to the correct update channels, run:
+
+----
+# yum repolist
+----
+
+Appliances must be subscribed to the following channels:
+
+* `cf-me-5.7-for-rhel-7-rpms`
+* `rhel-7-server-rpms`
+* `rhel-server-rhscl-7-rpms`
+
+If any appliance shows it is not registered or is missing a subscription to any of these channels, see _Registering and Updating {product-title}_ in https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.2/html-single/general_configuration/[General Configuration] to register and subscribe the appliance.
+
+.Updating the Appliances
+
+Follow this procedure to update appliances in your environment without migrating the database to the next major version of {product-title_short}. Note the appliance to perform each step on: some steps are to be performed only on the database-only appliances, and other steps only on the {product-title_short} appliances, while some steps apply to all appliances.
+
+. Power off the {product-title_short} appliances.
+. Power off the database-only appliances.
+. Back up each appliance:
+.. Back up the database of your appliance. Take a snapshot if possible.
+.. Back up the following files for disaster recovery, noting which appliance each comes from:
+  * `/var/www/miq/vmdb/GUID`
+  * `/var/www/miq/vmdb/REGION`
+.. Note the hostnames and IP addresses of each appliance. This information is available on the summary screen of the appliance console.
+. Start each database-only appliance.
+. Start each {product-title_short} appliance again, and stop `evmserverd` on each just after boot:
++
+------
+# systemctl stop evmserverd
+------
++
+[NOTE]
+====
+This step is not required on the database-only appliances, as `evmserverd` does not run on them.
+====
++
+. Apply updates by running the following on each appliance: 
++
+------
+# yum update
+------
++
+. Power off the {product-title_short} appliances. 
+. Reboot the database-only appliances.
+. Wait five minutes, then start the {product-title_short} appliances again.
+
+The appliances in your high availability environment are now up to date.
+


### PR DESCRIPTION
Hi Suyog,

I've created a new section in the high availability guide for applying minor updates (errata) to the environment while 1) not breaking the configuration; and 2) not upgrading the databases to the next version  (that content is yet to come in another BZ).

(BTW, I sourced the errata/update terminology from https://access.redhat.com/documentation/en-US/Red_Hat_Satellite/6.1/html/User_Guide/chap-Red_Hat_Satellite-User_Guide-Viewing_and_Applying_Errata.html -- it was a minor addition after Nick and Luke's reviews).

Please let me know what you think -- do you think the structure and language works? Feedback is welcome. A customer is waiting on this one, so feel free to deprioritize any other PRs you have for me in favour of this one. :)

http://file.bne.redhat.com/~dayparke/CloudForms/ApplyErrataHA/build/tmp/en-US/html-single/#updating-ha

Thanks so much Suyog!
Cheers,
Dayle