### PR TITLE
Bz1449906

### DIFF
--- a/common/create-playbook-service-catalog-item.adoc
+++ b/common/create-playbook-service-catalog-item.adoc
@@ -3,7 +3,7 @@ Create a catalog item that uses an Ansible Playbook to back it.
 
 [NOTE]
 ====
-Before creating an Ansible service, at least one repository, one playbook, and one credential must exist in the {product-title} inventory. Check your inventory and add the appropriate resources before creating an Ansible service. For more information on Ansible resounces, please see XXXXX
+Before creating an Ansible service, at least one repository, one playbook, and one credential must exist in the {product-title} inventory. Check your inventory and add the appropriate resources before creating an Ansible service. For more information, see https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.5/html-single/managing_providers/#automation_management_providers[Automation Management Providers] in _Managing Providers_.
 ====
 
 . Navigate to menu:Services[Catalogs].

--- a/common/service-dialog-creation.adoc
+++ b/common/service-dialog-creation.adoc
@@ -4,14 +4,17 @@
 . In *Dialog Information*, type in a *Label* and *Description*. Check the boxes for the buttons you want available at the bottom of the dialog form. The description will appear as hover text.
 +
 As you type in the *Label* of the dialog, it should appear in the *Dialog* pane on the left.
++
 .. Click image:1862.png[](*Add*), then image:1862.png[](*Add a New Tab to this Dialog*).
 .. Type in a *Label* and *Description* for this tab.
 +
 As you type in the *Label* of the tab, it should appear in the *Dialog* pane on the left under the dialog you are creating.
++
 .. Click image:1862.png[](*Add*), then image:1862.png[](*Add a New Box to this Tab*).
 .. Type in a *Label* and *Description* for this box.
 +
 As you type in the *Label* of the box, it should appear in the *Dialog* pane on the left under the tab you are creating.
++
 . Add an element to this box. Elements are controls that accept input.
 .. Click image:1862.png[](*Add*), then image:1862.png[](*Add a New Element to this Box*).
 .. Type in a *Label*, *Name*, and *Description* for this element.

--- a/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Catalogs_and_Services.adoc
+++ b/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Catalogs_and_Services.adoc
@@ -65,7 +65,7 @@ When provisioning a service, input will be needed from the requester. *Service D
 ===== Adding a Service Dialog
 [NOTE]
 ====
-When creating a service dialog for use with Ansible playbook catalog items, variable elements must use the prefix *param_* when assigning the value. For example, a new variable labeled *key1* should have its name input as *param_key1*.
+When creating a service dialog for use with Ansible playbook catalog items, variable elements must use the prefix *param_* when assigning the value. For example, a new variable labeled *key1* should have its value set as *param_key1*.
 ====
 include::common/service-dialog-creation.adoc[]
 

--- a/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Catalogs_and_Services.adoc
+++ b/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Catalogs_and_Services.adoc
@@ -1,4 +1,4 @@
-[[catalogs-services]]
+cd comkout [[catalogs-services]]
 == Catalogs and Services
 
 [[about-catalogs-and-services]]
@@ -63,7 +63,10 @@ When provisioning a service, input will be needed from the requester. *Service D
 
 [[adding-a-service-dialog]]
 ===== Adding a Service Dialog
-
+[NOTE]
+====
+When creating a service dialog for use with Ansible playbook catalog items, variable elements must use the prefix *param_* when assigning the value. For example, a new variable labeled *key1* should have its name input as *param_key1*.
+====
 include::common/service-dialog-creation.adoc[]
 
 [[importing-service-dialogs]]

--- a/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Catalogs_and_Services.adoc
+++ b/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Catalogs_and_Services.adoc
@@ -1,4 +1,4 @@
-cd comkout [[catalogs-services]]
+[[catalogs-services]]
 == Catalogs and Services
 
 [[about-catalogs-and-services]]


### PR DESCRIPTION
Hey Dayle,

I've created this PR based on BZ[1449906](https://bugzilla.redhat.com/show_bug.cgi?id=1449906). I added a note under 4.5.2.1. Adding a Service Dialog notfiying users of the *param* prefix requirement when setting variables for Ansible playbook service catalog items. I've created a preview here:

http://file.rdu.redhat.com/~cbudzilo/CloudForms/params/build/tmp/en-US/html-single/#service-dialogs

What do you think of the location? I thought it might be best to note when creating a service dialog, but it could just as easily fall under the main topic. 

-Chris