### PR TITLE
Updated the memory requirement for CloudForms in the installation gui…

### DIFF
--- a/doc-Installing_on_AWS/topics/installation.adoc
+++ b/doc-Installing_on_AWS/topics/installation.adoc
@@ -35,7 +35,7 @@ endif::cfme[]
 Uploading the {product-title} appliance file onto Amazon EC2 has the following requirements:
 
 * 44 GB of space on the chosen datastore.
-* 8 GB RAM.
+* 12 GB RAM.
 * 4 VCPUs.
 * An Amazon S3 bucket to store disk images.
 * A VM import service role (IAM role) named `vmimport`. 

--- a/doc-Installing_on_Red_Hat_Enterprise_Linux_OpenStack_Platform/topics/installation.adoc
+++ b/doc-Installing_on_Red_Hat_Enterprise_Linux_OpenStack_Platform/topics/installation.adoc
@@ -78,10 +78,9 @@ image:4941.png[title="Add Rule Dialog"]
 [[creating-a-custom-flavor]]
 === Creating a Custom Flavor
 
-A flavor is a resource allocation profile that specifies, for example, how many virtual CPUs and how much RAM can be allocated to an instance. You can, for example, run {product-title} on a Red Hat OpenStack m1.large flavor, which specifies a virtual machine with 4
-cores, 8GB RAM, and 80GB disk space. Creating a flavor to run {product-title} is optional.
+A flavor is a resource allocation profile that specifies, for example, how many virtual CPUs and how much RAM can be allocated to an instance. You can, for example, run {product-title} on a Red Hat OpenStack m1.large flavor, which specifies a virtual machine with 4 cores, 12 GB RAM, and 80 GB disk space. Creating a flavor to run {product-title} is optional.
 
-The following procedure demonstrates creating a flavor with the minimum requirements (4 cores, 8GB RAM, 44GB disk space) for {product-title}. For more information about flavors, see the Red Hat Enterprise Linux OpenStack Platform Administration User Guide.
+The following procedure demonstrates creating a flavor with the minimum requirements (4 cores, 12 GB RAM, 44 GB disk space) for {product-title}. For more information about flavors, see the Red Hat Enterprise Linux OpenStack Platform Administration User Guide.
 
 . Log in to the OpenStack dashboard as admin.
 . In the *Admin* tab, navigate to menu:System[Flavors].

--- a/doc-Installing_on_Red_Hat_Virtualization/topics/installation.adoc
+++ b/doc-Installing_on_Red_Hat_Virtualization/topics/installation.adoc
@@ -41,7 +41,7 @@ In Red Hat Enterprise Virtualization 3.6 and earlier, upload the `OVA` appliance
 Uploading the {product-title} appliance file to Red Hat Virtualization requires:
 
 * 44 GB of storage space on both the export domain and the local partition where `/tmp` resides, as the `OVF` archive is locally expanded into that directory.
-* 8 GB RAM.
+* 12 GB RAM.
 * 4 vCPUs.
 
 

--- a/doc-Installing_on_VMware_vSphere/topics/installation.adoc
+++ b/doc-Installing_on_VMware_vSphere/topics/installation.adoc
@@ -35,7 +35,7 @@ endif::cfme[]
 Uploading the {product-title} appliance file onto VMware vSphere systems has the following requirements:
 
 * 44 GB of space on the chosen vSphere datastore.
-* 8 GB RAM.
+* 12 GB RAM.
 * 4 VCPUs.
 * Administrator access to the vSphere Client.
 * Depending on your infrastructure, allow time for the upload.


### PR DESCRIPTION
…des from 8 GB to 12 GB as directed by the PM team.

@dayleparker Hi Dayle, 
This PR contains the change in the minimum memory requirement for CloudForms from 8GB to 12 GB for the following installation guides:
-doc-Installing_on_AWS
-doc-Installing_on_Red_Hat_Enterprise_Linux_OpenStack_Platform
-doc-Installing_on_Red_Hat_Virtualization
-doc-Installing_on_VMware_vSphere
(I've already made the change in the Azure installation guide via another PR.)
Could you please review and merge this change if it all looks OK? Thanks Dayle!
-Suyog