### PR TITLE
Docs for self-signed CA workarounds

### DIFF
--- a/common/openstack/adding-an-openstack-cloud-provider.adoc
+++ b/common/openstack/adding-an-openstack-cloud-provider.adoc
@@ -2,10 +2,9 @@
 When creating an OpenStack provider in {product-title}, select the OpenStack provider's `admin` user because it is the default administrator of the OpenStack `admin` tenant.
 When using the `admin` credentials, a user in {product-title} provisions into the `admin` tenant, and sees images, networks, and instances that are associated with the `admin` tenant.
 
-[NOTE]
-=====
+
 include::tenant-mapping.adoc[]
-=====
+
 
 [NOTE]
 =====
@@ -13,6 +12,11 @@ You can set whether {product-title} should use the Telemetry service or Advanced
 
 For more information, see https://access.redhat.com/documentation/en/red-hat-openstack-platform/8/architecture-guide/chapter-1-components#comp-telemetry[OpenStack Telemetry (ceilometer)] in the Red Hat OpenStack Platform _Architecture Guide_.
 =====
+
+[NOTE]
+====
+To authenticate the provider using a self-signed Certificate Authority (CA), configure the {product-title_short} appliance to trust the certificate using the steps in  xref:app-self_signed_CA[] before adding the provider.
+====
 
 . Navigate to menu:Compute[Clouds > Providers].
 

--- a/common/openstack/adding-an-openstack-infrastructure-provider.adoc
+++ b/common/openstack/adding-an-openstack-infrastructure-provider.adoc
@@ -9,6 +9,10 @@ You can set whether {product-title} should use the Telemetry service or Advanced
 For more information, see https://access.redhat.com/documentation/en/red-hat-openstack-platform/8/architecture-guide/chapter-1-components#comp-telemetry[OpenStack Telemetry (ceilometer)] in the Red Hat OpenStack Platform _Architecture Guide_.
 =====
 
+[NOTE]
+====
+To authenticate the provider using a self-signed Certificate Authority (CA), configure the {product-title_short} appliance to trust the certificate using the steps in  xref:app-self_signed_CA[] before adding the provider.
+====
 
 . Navigate to menu:Compute[Infrastructure > Providers].
 . Click  image:1847.png[Configuration] (*Configuration*), then click  image:1862.png[Add a New Infrastructure Provider] (*Add a New Infrastructure Provider*).

--- a/doc-Managing_Providers/cfme/master.adoc
+++ b/doc-Managing_Providers/cfme/master.adoc
@@ -38,6 +38,13 @@ include::topics/Containers_Providers.adoc[]
 :leveloffset: 1
 include::topics/Storage_Managers.adoc[]
 
+[appendix]
+[[appendix]]
+:leveloffset: 1
+= Appendix
+
+include::topics/app-self_signed_CA.adoc[]
+
 
 
 

--- a/doc-Managing_Providers/miq/index.adoc
+++ b/doc-Managing_Providers/miq/index.adoc
@@ -38,3 +38,9 @@ include::doc-Managing_Providers/miq/topics/Containers_Providers.adoc[]
 include::doc-Managing_Providers/miq/topics/Storage_Managers.adoc[]
 
 
+[appendix]
+[[appendix]]
+:leveloffset: 1
+= Appendix
+
+include::topics/app-self_signed_CA.adoc[]

--- a/doc-Managing_Providers/topics/Adding_a_Microsoft_System_Center_Virtual_Machine_Manager_Provider.adoc
+++ b/doc-Managing_Providers/topics/Adding_a_Microsoft_System_Center_Virtual_Machine_Manager_Provider.adoc
@@ -2,6 +2,11 @@
 
 After initial installation and creation of a {product-title} environment, add a Microsoft System Center Virtual Machine Manager provider to the appliance.
 
+[NOTE]
+====
+To authenticate the provider using a self-signed Certificate Authority (CA), configure the {product-title_short} appliance to trust the certificate using the steps in  xref:app-self_signed_CA[] before adding the provider.
+====
+
 . Navigate to menu:Compute[Infrastructure > Providers].
 . Click  image:1847.png[] (*Configuration*), then click  image:1862.png[] (*Add a New Infrastructure Provider*).
 . Enter the *Name* of the provider to add.

--- a/doc-Managing_Providers/topics/app-self_signed_CA.adoc
+++ b/doc-Managing_Providers/topics/app-self_signed_CA.adoc
@@ -1,0 +1,26 @@
+[[app-self_signed_CA]]
+== Using a Self-Signed CA Certificate 
+
+Adding a self-signed Certificate Authority (CA) for SSL authentication requires additional configuration on OpenStack Platform and Microsoft System Center Virtual Machine Manager providers.
+
+[NOTE]
+====
+This procedure is not required for OpenShift Container Platform, Red Hat Virtualization, or middleware manager providers. These steps are needed only for providers that do not have the option to select *SSL trusting custom CA* as a *Security Protocol* in the user interface.
+====
+
+Before adding the provider, configure the following:
+
+. Copy your provider's CA certificate in PEM format to `/etc/pki/ca-trust/source/anchors/` on your {product-title_short} appliance.
+. Update the trust settings on the appliance:
++
+------
+# update-ca-trust
+------
++
+. Restart the EVM processes on the server:
++
+------
+# rake evm:restart
+------
+
+The CA certificate is added to the appliance, and you can add the provider to {product-title_short}.

--- a/doc-Managing_Providers/topics/app-self_signed_CA.adoc
+++ b/doc-Managing_Providers/topics/app-self_signed_CA.adoc
@@ -1,7 +1,7 @@
 [[app-self_signed_CA]]
 == Using a Self-Signed CA Certificate 
 
-Adding a self-signed Certificate Authority (CA) for SSL authentication requires additional configuration on OpenStack Platform and Microsoft System Center Virtual Machine Manager providers.
+Adding a self-signed Certificate Authority (CA) certificate for SSL authentication requires additional configuration on OpenStack Platform and Microsoft System Center Virtual Machine Manager (SCVMM) providers.
 
 [NOTE]
 ====


### PR DESCRIPTION
Hi Suyog,

I've added an appendix on adding a self-signed CA, and notes in OpenStack and SCVMM sections linking to this appendix, as they seem to be the only providers affected by this now (ie. there is SSL validation in the UI, but no option for a self-signed cert). 
Please let me know if you have questions or comments -- I'll apply any SME feedback later so we can get this in for GA.

https://bugzilla.redhat.com/show_bug.cgi?id=1448711

http://file.bne.redhat.com/~dayparke/CloudForms/SSLCAcert/build/tmp/en-US/html-single/#app-self_signed_CA

Many thanks!
Dayle