### PR TITLE
[EUWE] changed link to deployment planning guide to more accurate section

### DIFF
--- a/doc-Configuring_High_Availability/topics/Installation.adoc
+++ b/doc-Configuring_High_Availability/topics/Installation.adoc
@@ -8,7 +8,7 @@ This chapter outlines the steps for installing and configuring the {product-titl
 
 The primary database-only appliance functions as an external database to the {product-title_short} appliances.
 
-. Deploy a {product-title_short} appliance with an extra partition for the database at a size appropriate for your deployment. For recommendations on disk space, see https://access.redhat.com/documentation/en/red-hat-cloudforms/4.2/paged/deployment-planning-guide/chapter-2-planning[Planning] in the _Deployment Planning Guide_.
+. Deploy a {product-title_short} appliance with an extra partition for the database at a size appropriate for your deployment. For recommendations on disk space, see https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.2/html/deployment_planning_guide/introduction#database-requirements[Database Requirements] in the _Deployment Planning Guide_.
 . Configure time synchronization on the appliance:
 .. Edit `/etc/chronyd.conf` with valid NTP server information.
 .. Re-synchronize time information across the appliances:
@@ -56,7 +56,7 @@ After installing and configuring an empty database-only appliance in xref:instal
 This must be configured from the {product-title_short} appliance before the primary and secondary database-only appliances can be configured.
 ====
 
-. Deploy a {product-title_short} appliance with an extra partition for the database at a size appropriate for your deployment. For recommendations on disk space, see https://access.redhat.com/documentation/en/red-hat-cloudforms/4.2/paged/deployment-planning-guide/chapter-2-planning[Planning] in the _Deployment Planning Guide_.
+. Deploy a {product-title_short} appliance with an extra partition for the database at a size appropriate for your deployment. For recommendations on disk space, see https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.2/html/deployment_planning_guide/introduction#database-requirements[Database Requirements] in the _Deployment Planning Guide_.
 . Configure time synchronization on the appliance:
 .. Edit `/etc/chronyd.conf` with valid NTP server information.
 .. Re-synchronize time information across the appliances:
@@ -126,7 +126,7 @@ The hostname must be visible to all appliances that communicate with this databa
 
 The standby database-only appliance is a copy of the primary database-only appliance and takes over the role of primary database in case of failure.
 
-. Deploy a {product-title_short} appliance with an extra partition for the database that is the same size as the primary database-only appliance, as it will contain the same data. For recommendations on disk space, see https://access.redhat.com/documentation/en/red-hat-cloudforms/4.2/paged/deployment-planning-guide/chapter-2-planning[Planning] in the _Deployment Planning Guide_.
+. Deploy a {product-title_short} appliance with an extra partition for the database that is the same size as the primary database-only appliance, as it will contain the same data. For recommendations on disk space, see https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.2/html/deployment_planning_guide/introduction#database-requirements[Database Requirements] in the _Deployment Planning Guide_.
 . Configure time synchronization on the appliance:
 .. Edit `/etc/chronyd.conf` with valid NTP server information.
 .. Re-synchronize time information across the appliances:
@@ -185,7 +185,7 @@ Verify the configuration on the appliance console details screen for the standby
 Install a second virtual machine with a {product-title_short} appliance and any additional appliances in the region using the following steps:
 
 
-. Deploy a {product-title_short} appliance with an extra partition for the database at a size appropriate for your deployment. For recommendations on disk space, see https://access.redhat.com/documentation/en/red-hat-cloudforms/4.2/paged/deployment-planning-guide/chapter-2-planning[Planning] in the _Deployment Planning Guide_.
+. Deploy a {product-title_short} appliance with an extra partition for the database at a size appropriate for your deployment. For recommendations on disk space, see https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.2/html/deployment_planning_guide/introduction#database-requirements[Database Requirements] in the _Deployment Planning Guide_.
 . Configure time synchronization on the appliance:
 .. Edit `/etc/chronyd.conf` with valid NTP server information.
 .. Re-synchronize time information across the appliances:


### PR DESCRIPTION
Hi Suyog,

After some discussion with Felix and Taeho from GSS, I decided to update the link to info in the Deployment Planning Guide to the Database Requirements section (instead of Planning) throughout the Installation chapter, as it gives better guidance: https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.2/html/deployment_planning_guide/introduction#database-requirements

Preview:
http://file.bne.redhat.com/~dayparke/CloudForms/HA-storage/build/tmp/en-US/html-single/#installation

Would you mind merging if you think this looks OK? I'll cherry-pick to master afterwards.

Thank you,
Dayle