### PR TITLE
Added note about obtaining a self-signed CA from Openshift Hawkular

### DIFF
--- a/common/provider-ocp-add-container.adoc
+++ b/common/provider-ocp-add-container.adoc
@@ -36,6 +36,14 @@ The *Hostname* must use a unique fully qualified domain name.
 .. Select a *Security Protocol* method to specify how to authenticate the provider:
 * *SSL*: Authenticate the provider securely using a trusted Certificate Authority. Select this option if the provider has a valid SSL certificate and it is signed by a trusted Certificate Authority. No further configuration is required for this option.
 * *SSL trusting custom CA*: Authenticate the provider with a self-signed certificate. For this option, copy your provider’s CA certificate to the *Trusted CA Certificates* box in PEM format.
++
+[NOTE]
+====
+In OpenShift, the default deployment of the router generates certificates during installation, which can be used with the *SSL trusting custom CA* option. Connecting a Hawkular endpoint with this option requires the CA certificate that the cluster uses for service certificates, which is stored in `/etc/origin/master/service-signer.crt` on the first master in a cluster. You can also obtain the certificate from the cluster by running the following on your provider:
+
+  # oc get secrets $(oc get secrets -n default -o jsonpath='{.items[?(@.type=="kubernetes.io/service-account-token")].metadata.name}{"\n"}' | grep  -Eo "router.+" | awk '{print $1}') -n default -o jsonpath='{.data.ca\.crt}{"\n"}' | base64 -d
+====
++
 * *SSL without validation*: Authenticate the provider insecurely using SSL. (Not recommended)
 .. Enter the *Hostname* or IPv4 or IPv6 address of the provider.
 .. Enter the *API Port* if your Hawkular provider uses a non-standard port for access. The default port is `443`.


### PR DESCRIPTION
Hi Suyog,

After some discussions with CloudForms engineering and some members of the OpenShift and CFME SBRs, I've added a note to the Hawkular endpoint section about obtaining the self-signed SSL certs to make it easier for users.

There might be future work on this, but I think this is all that's needed on this bug for now. If any more SME feedback comes in on the topic, I'll address it in a new BZ.

http://file.bne.redhat.com/~dayparke/CloudForms/SSL-customCA/build/tmp/en-US/html-single/#adding_openshift_provider

https://bugzilla.redhat.com/show_bug.cgi?id=1457036

Many thanks Suyog! Please let me know if you have questions. (Note to self -- this is only for 4.5)
Cheers,
Dayle