### PR TITLE
Bz#1463486 OCP name change

### DIFF
--- a/doc-Managing_Providers/topics/Containers_Providers.adoc
+++ b/doc-Managing_Providers/topics/Containers_Providers.adoc
@@ -58,7 +58,7 @@ Use the OpenShift Cluster Metrics plug-in to collect node, pod, and container me
 
 * Configure {product-title} to allow for all three https://access.redhat.com/documentation/en/red-hat-cloudforms/4.1/deployment-planning-guide/#assigning_the_capacity_and_utilization_server_roles[*Capacity & Utilization* server roles].
 
-* Enable cluster metrics using the https://access.redhat.com/documentation/en-us/openshift_container_platform/3.5/html-single/installation_and_configuration/#install-config-cluster-metrics[OpenShift Enterprise documentation].
+* Enable cluster metrics using the https://access.redhat.com/documentation/en-us/openshift_container_platform/3.5/html-single/installation_and_configuration/#install-config-cluster-metrics[OpenShift Container Platform documentation].
 
 :leveloffset: 2
 include::Adding_an_OpenShift_Provider.adoc[]

--- a/doc-Managing_Providers/topics/Containers_Providers.adoc
+++ b/doc-Managing_Providers/topics/Containers_Providers.adoc
@@ -23,7 +23,7 @@ You can manage policies for containers entities by adding tags. All containers e
 [[Obtaining_OpenShift_Container_Platform_Management_Token]]
 = Obtaining an OpenShift Container Platform Management Token
 
-When deploying OpenShift Enterprise using `openshift-ansible-3.0.20` (or later versions), the OpenShift Container Platform link:https://docs.openshift.com/container-platform/latest/admin_guide/service_accounts.html[service account] and link:https://docs.openshift.com/container-platform/latest/admin_guide/manage_authorization_policy.html[roles] required by {product-title} are installed by default.
+When deploying OpenShift using `openshift-ansible-3.0.20` (or later versions), the OpenShift Container Platform link:https://docs.openshift.com/container-platform/latest/admin_guide/service_accounts.html[service account] and link:https://docs.openshift.com/container-platform/latest/admin_guide/manage_authorization_policy.html[roles] required by {product-title} are installed by default.
 
 [NOTE]
 ====

--- a/doc-Managing_Providers/topics/Managing_Containers.adoc
+++ b/doc-Managing_Providers/topics/Managing_Containers.adoc
@@ -19,7 +19,7 @@ The collected information includes all the data available in other (infrastructu
 
 [NOTE]
 ====
-For Amazon EC2 (AWS) and Google Cloud Engine (GCE) support, OpenShift must be installed using the relevant cloud provider. For more information, see the https://access.redhat.com/documentation/en/openshift-container-platform/[OpenShift Enterprise Installation and Configuration Guide], ensuring to use the desired version of OpenShift.
+For Amazon EC2 (AWS) and Google Cloud Engine (GCE) support, OpenShift must be installed using the relevant cloud provider. For more information, see the https://access.redhat.com/documentation/en/openshift-container-platform/[OpenShift Container Platform Installation and Configuration Guide], ensuring you use the desired version of OpenShift.
 ====
 
 

--- a/doc-QuickStart_OpenShift_Provider_Guide/cfme/docinfo.xml
+++ b/doc-QuickStart_OpenShift_Provider_Guide/cfme/docinfo.xml
@@ -1,9 +1,9 @@
-<title>Quick Start for Red Hat OpenShift Enterprise and Red Hat CloudForms</title>
+<title>Quick Start for Red Hat OpenShift Container Platform and Red Hat CloudForms</title>
 <productname>Red Hat CloudForms</productname>
 <productnumber>4.5</productnumber>
-<subtitle>Adding Red Hat OpenShift Enterprise (with Metrics Enabled) as a Container Provider</subtitle>
+<subtitle>Adding Red Hat OpenShift Container Platform (with Metrics Enabled) as a Container Provider</subtitle>
 <abstract>
-   <para>This document provides a quick guide for integrating Red Hat OpenShift Enterprise container services (with metrics enabled) with Red Hat CloudForms. It is intended as an abridged reference for users already familiar with Red Hat CloudForms, Red Hat OpenShift Enterprise, and Red Hat Enterprise Linux.</para>
+   <para>This document provides a quick guide for integrating Red Hat OpenShift Container Platform container services (with metrics enabled) with Red Hat CloudForms. It is intended as an abridged reference for users already familiar with Red Hat CloudForms, Red Hat OpenShift Container Platform, and Red Hat Enterprise Linux.</para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/doc-QuickStart_OpenShift_Provider_Guide/cfme/master.adoc
+++ b/doc-QuickStart_OpenShift_Provider_Guide/cfme/master.adoc
@@ -1,4 +1,4 @@
-= Integration with Red Hat OpenShift Enterprise
+= Integration with Red Hat OpenShift Container Platform
 :vernum: 4.5
 :doctype: article
 :imagesdir: images
@@ -26,12 +26,12 @@ include::topics/overview.adoc[]
 include::topics/prerequisites.adoc[]
 
 [[ose-metrics]]
-= Enabling OpenShift Enterprise Metrics
+= Enabling OpenShift Container Platform Metrics
 
 include::topics/ose-metrics.adoc[]
 
 [[Obtaining_OpenShift_Enterprise_Management_Token]]
-= Retrieving the OpenShift Enterprise Management Token
+= Retrieving the OpenShift Container Platform Management Token
 
 include::topics/ose-retrieve-tokens.adoc[]
 
@@ -47,7 +47,7 @@ include::topics/ose-config-cfmiq.adoc[]
 include::common/smartstate.adoc[]
 
 [[integration]]
-= Adding OpenShift Enterprise as a Container Provider
+= Adding OpenShift Container Platform as a Container Provider
 
 include::topics/provider-ose-add-container.adoc[]
 

--- a/doc-QuickStart_OpenShift_Provider_Guide/miq/docinfo.xml
+++ b/doc-QuickStart_OpenShift_Provider_Guide/miq/docinfo.xml
@@ -1,9 +1,9 @@
-<title>Quick Start for Red Hat OpenShift Enterprise and ManageIQ</title>
+<title>Quick Start for Red Hat OpenShift Container Platform and ManageIQ</title>
 <productname>ManageIQ</productname>
 <productnumber>0</productnumber>
-<subtitle>Adding Red Hat OpenShift Enterprise (with Metrics Enabled) as a Container Provider</subtitle>
+<subtitle>Adding Red Hat OpenShift Container Platform (with Metrics Enabled) as a Container Provider</subtitle>
 <abstract>
-   <para>This document provides a quick guide for integrating Red Hat OpenShift Enterprise container services (with metrics enabled) with ManageIQ. It is intended as an abridged reference for users already familiar with ManageIQ, Red Hat OpenShift Enterprise, and Red Hat Enterprise Linux.</para>
+   <para>This document provides a quick guide for integrating Red Hat OpenShift Container Platform container services (with metrics enabled) with ManageIQ. It is intended as an abridged reference for users already familiar with ManageIQ, Red Hat OpenShift Container Platform, and Red Hat Enterprise Linux.</para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/doc-QuickStart_OpenShift_Provider_Guide/miq/index.adoc
+++ b/doc-QuickStart_OpenShift_Provider_Guide/miq/index.adoc
@@ -1,4 +1,4 @@
-= Integration with Red Hat OpenShift Enterprise
+= Integration with Red Hat OpenShift Container Platform
 :vernum: 0
 :doctype: article
 :imagesdir: images
@@ -21,12 +21,12 @@ include::common/attributes/miq.adoc[]
 include::topics/overview.adoc[]
 
 [[ose-metrics]]
-= Configuring OpenShift Enterprise Metrics
+= Configuring OpenShift Container Platform Metrics
 
 include::topics/ose-metrics.adoc[]
 
 [[Obtaining_OpenShift_Enterprise_Management_Token]]
-= Retrieving the OpenShift Enterprise Management Token
+= Retrieving the OpenShift Container Platform Management Token
 
 include::topics/ose-retrieve-tokens.adoc[]
 

--- a/doc-QuickStart_OpenShift_Provider_Guide/topics/ose-config-cfmiq.adoc
+++ b/doc-QuickStart_OpenShift_Provider_Guide/topics/ose-config-cfmiq.adoc
@@ -3,7 +3,7 @@ Configuring {product-title_short} involves two steps:
 . xref:cf-caputils[], and 
 . xref:cf-smartproxy[]
 
-These steps are required to allow {product-title_short} to collect metrics from OpenShift Enterprise (xref:ose-metrics[]) and use them to perform a SmartState analysis. You can choose different servers to perform either function; the following sections assume that you will.
+These steps are required to allow {product-title_short} to collect metrics from OpenShift Container Platform (xref:ose-metrics[]) and use them to perform a SmartState analysis. You can choose different servers to perform either function; the following sections assume that you will.
 
 
 [[cf-caputils]]

--- a/doc-QuickStart_OpenShift_Provider_Guide/topics/ose-metrics.adoc
+++ b/doc-QuickStart_OpenShift_Provider_Guide/topics/ose-metrics.adoc
@@ -1,6 +1,7 @@
 // https://access.redhat.com/documentation/en/openshift-enterprise/version-3.2/installation-and-configuration/#install-config-cluster-metrics
+// NOTE: This whole section may need updating as OCP 3.3 + are much different: https://access.redhat.com/documentation/en-us/openshift_container_platform/3.3/html-single/installation_and_configuration/#install-config-cluster-metrics
 
-In order for {product-title_short} to collect OpenShift Enterprise node, pod, and container, you must first enable _cluster metrics_ for your OpenShift cluster. This involves running the OpenShift Metrics services inside your cluster. If cluster metrics are already enabled on OpenShift, skip this section and proceed to xref:Obtaining_OpenShift_Enterprise_Management_Token[].
+In order for {product-title_short} to collect OpenShift Container Platform node, pod, and container, you must first enable _cluster metrics_ for your OpenShift cluster. This involves running the OpenShift Metrics services inside your cluster. If cluster metrics are already enabled on OpenShift, skip this section and proceed to xref:Obtaining_OpenShift_Enterprise_Management_Token[].
 
 [NOTE]
 ===================
@@ -22,7 +23,7 @@ If you deployed OpenShift using `openshift-ansible-3.0.20`, then the service acc
 
 To create these accounts:
 
-. Log in as an administrator to any node within the OpenShift Enterprise cluster.
+. Log in as an administrator to any node within the OpenShift Container Platform cluster.
 . Open a terminal.
 . Switch to the *openshift-infra* project:
 +
@@ -61,23 +62,23 @@ $ oadm policy add-cluster-role-to-user \
 [[ose-metrics-storage]]
 == Configuring Metrics Components
 
-The Metrics Deployer installs and configures the components required for OpenShift Enterprise metrics. By default, the Metrics Deployer uses _self-signed certificates_ to secure communication between components. This document assumes that you will use this default. For information on alternative secure communication configurations, see https://access.redhat.com/documentation/en/openshift-enterprise/version-3.2/installation-and-configuration/#metrics-deployer-using-secrets[Using Secrets] in the OpenShift Enterprise _Installation and Configuration_ documentation.
+The Metrics Deployer installs and configures the components required for OpenShift Container Platform metrics. By default, the Metrics Deployer uses _self-signed certificates_ to secure communication between components. This document assumes that you will use this default. For information on alternative secure communication configurations, see https://access.redhat.com/documentation/en/openshift-enterprise/version-3.2/installation-and-configuration/#metrics-deployer-using-secrets[Using Secrets] in the OpenShift Container Platform _Installation and Configuration_ documentation.
 
 [NOTE]
 ===================
-This section is an abridged version of a more detailed chapter, namely https://access.redhat.com/documentation/en/openshift-enterprise/version-3.2/installation-and-configuration/#metrics-data-storage[Metrics Data Storage] in the OpenShift Enterprise _Installation and Configuration_ documentation. Refer to that chapter for more information on how to deploy the metrics plug-in using persistent and non-persistent storage.
+This section is an abridged version of a more detailed chapter, namely https://access.redhat.com/documentation/en/openshift-enterprise/version-3.2/installation-and-configuration/#metrics-data-storage[Metrics Data Storage] in the OpenShift Container Platform _Installation and Configuration_ documentation. Refer to that chapter for more information on how to deploy the metrics plug-in using persistent and non-persistent storage.
 ===================
 
 [[ose-metrics-deploy]]
 === Deploying the Metrics Components
 
-OpenShift Enterprise uses _Hawkular Metrics_ as its metrics engine. The Metrics Deployer will install the Hawkular Metrics service; however, you need to provide the external hostname so that {product-title_short} can reach the Hawkular Metrics service. The base configuration of the Metrics Deployer is defined in the `/usr/share/openshift/examples/infrastructure-templates/enterprise/metrics-deployer.yaml` file.
+OpenShift Container Platform uses _Hawkular Metrics_ as its metrics engine. The Metrics Deployer will install the Hawkular Metrics service; however, you need to provide the external hostname so that {product-title_short} can reach the Hawkular Metrics service. The base configuration of the Metrics Deployer is defined in the `/usr/share/openshift/examples/infrastructure-templates/enterprise/metrics-deployer.yaml` file.
 
-Before deploying OpenShift metrics, choose a storage option, then log in as an administrator to any node within the OpenShift Enterprise cluster. From there, open a terminal and run the corresponding command:
+Before deploying OpenShift metrics, choose a storage option, then log in as an administrator to any node within the OpenShift Container Platform cluster. From there, open a terminal and run the corresponding command:
 
 Deploying with persistent storage::
 
-With _persistent storage_, OpenShift metrics will be stored on a persistent volume. This offers metrics data protection by allowing it to survive a pod recreation or restart. OpenShift metrics requires a specifically configured persistent volume; see https://access.redhat.com/documentation/en/openshift-enterprise/version-3.2/architecture/#architecture-additional-concepts-storage[Persistent Volumes] in the OpenShift Enterprise _Architecture_ documentation. 
+With _persistent storage_, OpenShift metrics will be stored on a persistent volume. This offers metrics data protection by allowing it to survive a pod recreation or restart. OpenShift metrics requires a specifically configured persistent volume; see https://access.redhat.com/documentation/en/openshift-enterprise/version-3.2/architecture/#architecture-additional-concepts-storage[Persistent Volumes] in the OpenShift Container Platform _Architecture_ documentation. 
 +
 //When preparing the persistent volume, note its _size_, as this will be used later in xref:ose-metrics-deploy[].
 +
@@ -124,9 +125,9 @@ For either command, replace _HAWKULARHOST_ with the external hostname that {prod
 Either storage method deploys the required metrics components and creates the necessary service accounts. In particular, the metrics components will be configured to also use the specified _HAWKULARHOST_ as its public endpoint.
 
 [[ose-metrics-finish]]
-=== Applying the Hawkular Metrics Settings to OpenShift Enterprise 
+=== Applying the Hawkular Metrics Settings to OpenShift Container Platform 
 
-After deploying the metrics components, configure OpenShift Enterprise to use them:
+After deploying the metrics components, configure OpenShift Container Platform to use them:
 
 . Open the OpenShift Master Configuration file at `/etc/origin/master/master-config.yaml`. Add the *metricsPublicURL* parameter to the *assetConfig* section, specifying the _HAWKULARHOST_ you specified in xref:ose-metrics-deploy[]:
 +
@@ -136,7 +137,7 @@ assetConfig:
     ...
     metricsPublicURL: "https://_HAWKULARHOST_/hawkular/metrics"
 --------------------------
-. Restart your OpenShift Enterprise master host:
+. Restart your OpenShift Container Platform master host:
 +
 [literal,subs="+quotes"]
 --------------------------

--- a/doc-QuickStart_OpenShift_Provider_Guide/topics/ose-retrieve-tokens.adoc
+++ b/doc-QuickStart_OpenShift_Provider_Guide/topics/ose-retrieve-tokens.adoc
@@ -1,16 +1,23 @@
 // https://access.redhat.com/documentation/en/red-hat-cloudforms/4.1/managing-providers/#Obtaining_OpenShift_Enterprise_Management_Token
 
-After enabling cluster metrics on your OpenShift Enterprise deployment, retrieve the _management token_ while you are still logged in to the OpenShift Enterprise host. This will be required later in xref:integration[].
+After enabling cluster metrics on your OpenShift Container Platform deployment, retrieve the _management token_ while you are still logged in to the OpenShift Container Platform host. This will be required later in xref:integration[].
 
-For OpenShift Enterprise 3.2 and Later::
+For OpenShift Container Platform 3.3 or later::
 
-Provide the token needed to add an OpenShift Enterprise provider.
+Provide the token needed to add an OpenShift Container Platform 3.3 (or later) provider.
+
+include::common/provider-ocp-mgt-token.adoc[]
+
+
+For OpenShift Enterprise 3.2::
+
+Provide the token needed to add an OpenShift Enterprise 3.2 provider.
 
 include::common/provider-ose-mgt-token-3_2.adoc[]
 
 For OpenShift Enterprise 3.1::
 
-Provide the token needed to add an OpenShift Enterprise provider.
+Provide the token needed to add an OpenShift Enterprise 3.1 provider.
 
 include::common/provider-ose-mgt-token-3_1.adoc[]
 

--- a/doc-QuickStart_OpenShift_Provider_Guide/topics/overview.adoc
+++ b/doc-QuickStart_OpenShift_Provider_Guide/topics/overview.adoc
@@ -1,5 +1,5 @@
-This guide walks you through adding a Red Hat OpenShift Enterprise cluster to a {product-title} container provider catalog. This deployment focuses on enabling the OpenShift Enterprise cluster metrics plug-in, so that {product-title_short} can collect information from an OpenShift Enterprise cluster upon integration.
+This guide walks you through adding a Red Hat OpenShift Container Platform cluster to a {product-title} container provider catalog. This deployment focuses on enabling the OpenShift Container Platform cluster metrics plug-in, so that {product-title_short} can collect information from an OpenShift Container Platform cluster upon integration.
 
-Each procedure in this guide is covered in greater detail in the https://access.redhat.com/documentation/en/red-hat-cloudforms/[{product-title}] and https://access.redhat.com/documentation/en/openshift-container-platform/[OpenShift Enterprise] product documentation. However, links to the corresponding sections are provided for more detail.
+Each procedure in this guide is covered in greater detail in the https://access.redhat.com/documentation/en/red-hat-cloudforms/[{product-title}] and https://access.redhat.com/documentation/en/openshift-container-platform/[OpenShift Container Platform] product documentation. However, links to the corresponding sections are provided for more detail.
 
 The following sections will describe the required configuration for both products prior to integration.

--- a/doc-QuickStart_OpenShift_Provider_Guide/topics/prerequisites.adoc
+++ b/doc-QuickStart_OpenShift_Provider_Guide/topics/prerequisites.adoc
@@ -1,7 +1,7 @@
 This guide assumes that you have: 
 
 * link:https://access.redhat.com/documentation/en/openshift-enterprise/version-3.1/installation-and-configuration/[Already deployed {product-title}]
-* link:https://access.redhat.com/documentation/en/openshift-enterprise/version-3.2/installation-and-configuration/[Already deployed OpenShift Enterprise]
+* link:https://access.redhat.com/documentation/en/openshift-enterprise/version-3.2/installation-and-configuration/[Already deployed OpenShift Container Platform]
 
 
-When enabling metrics on OpenShift Enterprise, you can store your metrics data on _persistent_ or _non-persistent_ storage. To use persistent storage, you need to provision a persistent volume specifically for this purpose before xref:ose-metrics-storage[configuring the metrics components]. See https://access.redhat.com/documentation/en/openshift-enterprise/version-3.2/architecture/#architecture-additional-concepts-storage[Persistent Volumes] in the https://access.redhat.com/documentation/en/openshift-enterprise/version-3.2/architecture/[OpenShift Enterprise Architecture documentation] for more information.
+When enabling metrics on OpenShift Container Platform, you can store your metrics data on _persistent_ or _non-persistent_ storage. To use persistent storage, you need to provision a persistent volume specifically for this purpose before xref:ose-metrics-storage[configuring the metrics components]. See https://access.redhat.com/documentation/en/openshift-enterprise/version-3.2/architecture/#architecture-additional-concepts-storage[Persistent Volumes] in the https://access.redhat.com/documentation/en/openshift-enterprise/version-3.2/architecture/[OpenShift Container Platform Architecture documentation] for more information.

--- a/doc-QuickStart_OpenShift_Provider_Guide/topics/provider-ose-add-container.adoc
+++ b/doc-QuickStart_OpenShift_Provider_Guide/topics/provider-ose-add-container.adoc
@@ -7,13 +7,13 @@ At this point, you should now be ready to add your OpenShift cluster to {product
 . Navigate to menu:Compute[Containers > Providers].
 . Click  image:1847.png[] (*Configuration*), then click  image:1862.png[] (*Add a New Containers Provider*).
 . Enter a *Name* for the provider.
-. From the *Type* list, select *OpenShift Enterprise*.
+. From the *Type* list, select *OpenShift Container Platform*.
 . Enter the appropriate *Zone* for the provider. By default, the zone is set to `default`.
 // update starts here
 . In the *Default* tab of the *Endpoints* section, enter the fully qualified domain name of the provider in the *Hostname (or IPv4 or IPv6 address)* field. 
 . Enter the *Port* of the provider. The default port is `8443`.
 . In the *Token* and *Confirm Token* fields, enter token obtained earlier in xref:Obtaining_OpenShift_Enterprise_Management_Token[].
-. Click *Validate* to confirm that the {product-title} can connect to the OpenShift Enterprise provider using the provided token.
+. Click *Validate* to confirm that the {product-title} can connect to the OpenShift Container Platform provider using the provided token.
 . Next, click the *Hawkular* tab. From there, enter the _HAWKULARHOST_ (from xref:ose-metrics-deploy[]) in the *Hostname (or IPv4 or IPv6 address)* field.
 . Enter the *Port* of the _HAWKULARHOST_. The default port is `443`.
 . Click *Add*.


### PR DESCRIPTION
Hi Suyog,

I've updated the guide to reflect this product name change. The only places I've left "OpenShift Enterprise" is when we are specifically referring to OpenShift 3.2 or previous (the name changed to OCP in 3.3).

I left an older link to the OpenShift 3.2 guide in chapter 3, as the content needs a thorough update, but reflects what the 3.2 docs contain -- Andrew and I agreed this update/testing is out of scope for this bug. I created a new bug to track this future change: https://bugzilla.redhat.com/show_bug.cgi?id=1467135

Please let me know if you see any additional changes needed, or feel free to merge.

Cheers,  
Dayle