### PR TITLE
Revert guide titles to previous - Integration with OSE

### DIFF
--- a/doc-QuickStart_OpenShift_Provider_Guide/cfme/master.adoc
+++ b/doc-QuickStart_OpenShift_Provider_Guide/cfme/master.adoc
@@ -1,4 +1,4 @@
-= Integration with Red Hat OpenShift Container Platform
+= Integration with Red Hat OpenShift Enterprise
 :vernum: 4.5
 :doctype: article
 :imagesdir: images

--- a/doc-QuickStart_OpenShift_Provider_Guide/miq/index.adoc
+++ b/doc-QuickStart_OpenShift_Provider_Guide/miq/index.adoc
@@ -1,4 +1,4 @@
-= Integration with Red Hat OpenShift Container Platform
+= Integration with Red Hat OpenShift Enterprise
 :vernum: 0
 :doctype: article
 :imagesdir: images


### PR DESCRIPTION
This update reverts the guide title to Integration with OpenShift Enterprise in the cfme and miq folders, so that the guide will not break on Pantheon. The change was originally made in BZ1463486, PR #411

@adahms Andrew, would you mind having a quick look and merging this PR if I've fixed all the pieces correctly?