### PR TITLE
Updated the structure of the Catalogs and Services chapter.

### DIFF
--- a/common/catalog-item-creation.adoc
+++ b/common/catalog-item-creation.adoc
@@ -2,7 +2,9 @@
 . Click the *Catalog Items* accordion.
 . Click image:1847.png[](*Configuration*), and then image:1862.png[](*Add a New Catalog Item*).
 . Select the *Catalog Item Type* you are adding. The dialogs that appear will be filtered based on the selected type of provider. For example, you will only see templates residing on Red Hat Providers, if the *Catalog Item Type* is *Redhat*.
++
 image:2357.png[]
++
 . In the *Basic Info* subtab:
 .. Type a *Name/Description*.
 .. Check *Display in Catalog* to edit *Catalog*, *Dialog*, and *Entry Point(NS/Cls/Inst)* options.

--- a/common/service-dialog-creation.adoc
+++ b/common/service-dialog-creation.adoc
@@ -1,23 +1,23 @@
 . Navigate to menu:Automate[Customization].
 . Click the *Service Dialogs* accordion.
 . Click image:1847.png[](*Configuration*), and then image:1862.png[](*Add a new Dialog*).
-. In *Dialog Information*, type in a *Label* and *Description*. Check the boxes for the buttons you want available at the bottom of the dialog form. The description will appear as hover text.
+. In *Dialog Information*, enter a *Label* and *Description*. Check the boxes for the buttons you want available at the bottom of the dialog form. The description will appear as hover text.
 +
-As you type in the *Label* of the dialog, it should appear in the *Dialog* pane on the left.
+As you enter the *Label* of the dialog, it should appear in the *Dialog* pane on the left.
 +
 .. Click image:1862.png[](*Add*), then image:1862.png[](*Add a New Tab to this Dialog*).
-.. Type in a *Label* and *Description* for this tab.
+.. Enter a *Label* and *Description* for this tab.
 +
-As you type in the *Label* of the tab, it should appear in the *Dialog* pane on the left under the dialog you are creating.
+As you enter the *Label* of the tab, it should appear in the *Dialog* pane on the left under the dialog you are creating.
 +
 .. Click image:1862.png[](*Add*), then image:1862.png[](*Add a New Box to this Tab*).
-.. Type in a *Label* and *Description* for this box.
+.. Enter a *Label* and *Description* for this box.
 +
-As you type in the *Label* of the box, it should appear in the *Dialog* pane on the left under the tab you are creating.
+As you enter the *Label* of the box, it should appear in the *Dialog* pane on the left under the tab you are creating.
 +
 . Add an element to this box. Elements are controls that accept input.
 .. Click image:1862.png[](*Add*), then image:1862.png[](*Add a New Element to this Box*).
-.. Type in a *Label*, *Name*, and *Description* for this element.
+.. Enter a *Label*, *Name*, and *Description* for this element.
 +
 [IMPORTANT]
 ====
@@ -35,7 +35,7 @@ As you type in the *Label* of the box, it should appear in the *Dialog* pane on 
 |Drop Down Dynamic List|Use *Drop Down Dynamic List* if you want the list options to be created using automate methods. Use *Entry Point (NS/Cls/Inst)* to select an automate instance. Check *Show Refresh Button* to allow users to refresh the list options manually.
 |Radio Button|This element type serves the same purpose as *Drop Down List* but displays options using radio buttons.
 |Tag Control|Select a *Category* of tags you want assigned to the virtual machines associated with this service dialog. Check *Single Select* if only one tag can be selected.
-|Text Area Box|Provides text area for users to type in some text. You can also leave a message to users by typing in the *Default Value* field or leave it as blank.
+|Text Area Box|Provides text area for users to enter some text. You can also leave a message to users by typing in the *Default Value* field or leave it as blank.
 |Text Box|This element type serves the same purpose as *Text Area Box* with the option to check *Protected* so the text is shown as asterisks (*), instead of plain text.
 |====
 +
@@ -47,13 +47,13 @@ As you type in the *Label* of the box, it should appear in the *Dialog* pane on 
 . Click image:1847.png[](*Configuration*), and then image:1851.png[](*Edit this Dialog*).
 . Add a tab to the dialog.
 .. Click image:1862.png[](*Add*), then image:1862.png[](*Add a New Tab to this Dialog*).
-.. Type in a *Label* and *Description* for this tab.
+.. Enter a *Label* and *Description* for this tab.
 . Add a box to this tab.
 .. Click image:1862.png[](*Add*), then image:1862.png[](*Add a New Box to this Tab*).
-.. Type in a *Label* and *Description* for this box.
+.. Enter a *Label* and *Description* for this box.
 . Add an element to this box. Elements are controls that accept input.
 .. Click image:1862.png[](*Add*), then image:1862.png[](*Add a New Element to this Box*).
-.. Type in a *Label*, *Name*, and *Description* for this element.
+.. Enter a *Label*, *Name*, and *Description* for this element.
 +
 [IMPORTANT]
 ====
@@ -71,7 +71,7 @@ As you type in the *Label* of the box, it should appear in the *Dialog* pane on 
 |Drop Down Dynamic List|Use *Drop Down Dynamic List* if you want the list options to be created using automate methods. Use *Entry Point (NS/Cls/Inst)* to select an automate instance. Check *Show Refresh Button* to allow users to refresh the list options manually.
 |Radio Button|This element type serves the same purpose as *Drop Down List* but displays options using radio buttons.
 |Tag Control|Select a *Category* of tags you want assigned to the virtual machines associated with this service dialog. Check *Single Select* if only one tag can be selected.
-|Text Area Box|Provides text area for users to type in some text. You can also leave a message to users by typing in the *Default Value* field or leave it as blank.
+|Text Area Box|Provides text area for users to enter some text. You can also leave a message to users by typing in the *Default Value* field or leave it as blank.
 |Text Box|This element type serves the same purpose as *Text Area Box* with the option to check *Protected* so the text is shown as asterisks (*), instead of plain text.
 |====
 +

--- a/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Catalogs_and_Services.adoc
+++ b/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Catalogs_and_Services.adoc
@@ -3,7 +3,22 @@
 
 Through the use of catalogs, {product-title} provides support for multi-tier service provisioning to deploy layered workloads across hybrid environments. You can create customized dialogs that will give consumers of the services the ability to input just a few parameters and provision the entire service.
 
-.Terminology:
+.Terminology
+[width="100%",cols="40%,60%",options="header",]
+|====
+|Type|Information
+|Catalog Bundle|A group of templates.
+|Catalog Item|A single template.
+|Template|A template is a copy of a preconfigured virtual machine, designed to capture the installed software and software configurations, as well as the hardware configuration of the original virtual machine.
+|Dialog Tabs|Part of a service dialog.
+|Element|An item on a tab in a dialog. It can be a button, check box, drop down list, radio button, tag control, text area box, or a text box.
+|Provisioning Dialogs|Dialogs created for host provisioning, virtual machine migration, or virtual machine provisioning. The dialog name must be added to the appropriate provision instance to be processed.
+|Service Catalog|A catalog item or catalog bundle that is available for provisioning.
+|Service Dialogs|Made up of fully customizable tabs, items, and values for use with service provisioning.
+|====
+
+
+////
 
 *Catalog Bundle*:: A group of templates.
 *Catalog Item*:: A single template.
@@ -14,11 +29,14 @@ Through the use of catalogs, {product-title} provides support for multi-tier ser
 *Service Catalog*:: A catalog item or catalog bundle that is available for provisioning.
 *Service Dialogs*:: Made up of fully customizable tabs, items, and values for use with service provisioning.
 
+////
+
+
 
 [[service-dialogs]]
 ==== Service Dialogs
 
-When provisioning a service, input will be needed from the requester. *Service Dialogs* are used to take input from the user. This input is connected to a method in the *Automate* model that defines how the users input is translated into the provision request. Before creating a *Service Dialog*, be sure to plan what items you need the user to input.
+When provisioning a service, input will be needed from the requester. Service dialogs are used to take input from the user. This input is connected to a method in the Automate model that defines how the users input is translated into the provision request. Before creating a service dialog, be sure to plan what items you need the user to input.
 
 [[adding-a-service-dialog]]
 ===== Adding a Service Dialog
@@ -64,7 +82,7 @@ You will need to create a method that connects the values in the dialog with the
 
 A method is provided below that was created for the following scenario:
 
-* You want to provision a three-tiered Service that contains catalog items of web, app and DB. Each of these virtual machines (or cloud instances) has been tagged under the *Service* category with the appropriate value. Then, added as a catalog item and combined into a catalog bundle.
+* You want to provision a three-tiered service that contains catalog items of web, app and DB. Each of these virtual machines (or cloud instances) has been tagged under the *Service* category with the appropriate value. Then, added as a catalog item and combined into a catalog bundle.
 * The *Service Dialog* captures the selection of small, medium or large application in a dropdown called *service_type*. When referring to a value captured in an element in a dialog, the name of the element should be prefixed with *dialog_*. For example, *service_type* becomes *dialog_service_type* when used in the method.
 * The method will set the memory sizes for each of the catalog items based on the *service_type* selection.
 
@@ -182,8 +200,8 @@ Service methods have been split based on purpose.
 +
 . Click the *Methods* tab.
 . Click image:1847.png[](*Configuration*), then image:1862.png[](*Add a New Method*).
-. Type in a *Name* and *Display Name*.
-. In the *Data* field, type in the method contents.
+. Enter a *Name* and *Display Name*.
+. In the *Data* field, enter the method contents.
 . Click *Validate* and wait for your data entry to be successfully validated.
 . Click *Add*.
 image:6297.png[]
@@ -201,8 +219,8 @@ image:6297.png[]
 +
 . Click the *Instances* tab.
 . Click image:1847.png[](*Configuration*), then image:1862.png[](*Add a new Instance*).
-. Type in a *Name* and *Display Name*.
-. In the *Fields* area, type in the method's name in *Value*.
+. Enter a *Name* and *Display Name*.
+. In the *Fields* area, enter the method's name in *Value*.
 . Click *Add*.
 
 The instance is created so that it can be called from the *ServiceProvision* class.
@@ -233,8 +251,6 @@ Service methods have been split based on purpose.
 . In the *configurechilddialog* value, put the path to the method.
 . Click *Save* or *Add* if you are adding this to a new instance.
 
-Now that the catalog items, service dialog, dialog methods, and service provision instance have been created, you can create the catalog bundle.
-
 
 [[catalogs]]
 === Catalogs
@@ -262,7 +278,7 @@ DOMAIN must be a user-defined Domain and not the locked ManageIQ Domain. If nece
 . Navigate to menu:Services[Catalogs].
 . Click the *Catalog Items* accordion.
 . Click image:1847.png[](*Configuration*), and then image:1862.png[](*Add a New Catalog Bundle*).
-. In *Basic Info*, type in a name and description:
+. In *Basic Info*, enter a name and description:
 image:2362.png[]
 . Click *Display in Catalog*.
 . Select the appropriate dialog name.

--- a/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Catalogs_and_Services.adoc
+++ b/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Catalogs_and_Services.adoc
@@ -1,7 +1,7 @@
 [[catalogs-services]]
 == Catalogs and Services
 
-Through the use of catalogs, {product-title} provides support for multi-tier service provisioning to deploy layered workloads across hybrid environments. You can create customized dialogs that will give consumers of the services the ability to input just a few parameters and provision the entire service.
+Through the use of catalogs, {product-title} provides support for multi-tier service provisioning to deploy layered workloads across hybrid environments. You can create customized dialogs that will give consumers of the services the ability to input just a few parameters and provision the entire service. The following table lists the terminology associated with catalogs that you will use within the CloudForms user interface for service provisioning.
 
 .Terminology
 [width="100%",cols="40%,60%",options="header",]

--- a/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Catalogs_and_Services.adoc
+++ b/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Catalogs_and_Services.adoc
@@ -1,60 +1,19 @@
 [[catalogs-services]]
 == Catalogs and Services
 
-[[about-catalogs-and-services]]
-=== About Catalogs and Services
-
 Through the use of catalogs, {product-title} provides support for multi-tier service provisioning to deploy layered workloads across hybrid environments. You can create customized dialogs that will give consumers of the services the ability to input just a few parameters and provision the entire service.
 
-[[terminology]]
-=== Terminology
+.Terminology:
 
-*Terminology*
+*Catalog Bundle*:: A group of templates.
+*Catalog Item*:: A single template.
+*Template*:: A template is a copy of a preconfigured virtual machine, designed to capture the installed software and software configurations, as well as the hardware configuration of the original virtual machine.
+*Dialog Tabs*:: Part of a service dialog.
+*Element*:: An item on a tab in a dialog. It can be a button, check box, drop down list, radio button, tag control, text area box, or a text box.
+*Provisioning Dialogs*:: Dialogs created for host provisioning, virtual machine migration, or virtual machine provisioning. The dialog name must be added to the appropriate provision instance to be processed.
+*Service Catalog*:: A catalog item or catalog bundle that is available for provisioning.
+*Service Dialogs*:: Made up of fully customizable tabs, items, and values for use with service provisioning.
 
-*Catalog Bundle*:: A grouping of Templates.
-*Catalog Item*:: A single Template or a group of Templates (catalog bundle).
-*Dialog Tabs*:: Part of a Service Dialog.
-*Element*:: An item on a tab in a Dialog. It can be a Button, Check Box, Drop Down List, Radio Button, Tag Control, Text Area Box, or a Text Box.
-*Provisioning Dialogs*:: Dialogs created for Host Provisioning, VM Migration, or VM Provisioning. The dialog name must be added to the appropriate provision instance to be processed.
-*Service Catalog*:: A catalog item or Catalog bundle that is available for provisioning.
-*Service Dialogs*:: Made up of fully customizable tabs, items, and values for use with Service provisioning.
-*Template*:: A template is a copy of a preconfigured virtual machine, designed to capture installed software and software configurations, as well as the hardware configuration, of the original virtual machine.
-
-[[catalogs]]
-=== Catalogs
-
-Catalogs are used to create groups of virtual machines or instances for provisioning. For example, a complete package of a database server, desktop with specialized software already on it, and a firewall. You will need to complete the following steps to create and provision a service catalog.
-
-. Create *Catalog Items* for each virtual machine or instance that will be part of the service.
-. Create a *Service* dialog. For example, create a dropdown with three options small, medium, and large.
-. Create a method for the Service Dialog. This method defines what each of the options means to each of the individual virtual machines or cloud instances for the service. This method is called from a service provisioning instance in the Automate model.
-. Create an instance in the `DOMAIN/Service/Provisioning/StateMachines/ServiceProvision_Template` class that calls the method.
-+
-[NOTE]
-====
-DOMAIN must be a user-defined Domain and not the locked ManageIQ Domain. If necessary, you can copy the class from the ManageIQ domain into a custom domain.
-====
-+
-. Associate method with Automate instance.
-. Create a *Catalog Bundle*, adding each of the catalog items to it. Select the *Service Dialog* you created. Use the instance created in the `DOMAIN/Service/Provisioning/StateMachines/ServiceProvision_Template` class as the *Entry Point*. Check *Display in Catalog* box.
-. Provision a service.
-
-[[creating-a-catalog-item]]
-==== Creating a Catalog Item
-
-Create a catalog item for each virtual machine or cloud instance that will be part of the service.
-
-include::common/catalog-item-creation.adoc[]
-
-[[create-playbook-service-catalog-item]]
-===== Creating an Ansible Playbook Service Catalog Item
-
-include::common/create-playbook-service-catalog-item.adoc[]
-
-[[create-tower-catalog-item]]
-===== Creating an Ansible Tower Service Catalog Item
-
-include::common/create-tower-catalog-item.adoc[]
 
 [[service-dialogs]]
 ==== Service Dialogs
@@ -88,6 +47,7 @@ You can share service dialogs between appliances using the export and import fea
 . In the *Import/Export* accordion, click *Service Dialog Import/Export*.
 . In the *Export* area, select the service dialogs that you want to export.
 . Click *Export*.
+
 
 [[methods]]
 ==== Methods
@@ -275,6 +235,27 @@ Service methods have been split based on purpose.
 
 Now that the catalog items, service dialog, dialog methods, and service provision instance have been created, you can create the catalog bundle.
 
+
+[[catalogs]]
+=== Catalogs
+
+Catalogs are used to create groups of virtual machines or instances for provisioning. For example, a complete package of a database server, desktop with specialized software already on it, and a firewall. You will need to complete the following steps to create and provision a service catalog.
+
+. Create *Catalog Items* for each virtual machine or instance that will be part of the service.
+. Create a *Service* dialog. For example, create a dropdown with three options small, medium, and large.
+. Create a method for the Service Dialog. This method defines what each of the options means to each of the individual virtual machines or cloud instances for the service. This method is called from a service provisioning instance in the Automate model.
+. Create an instance in the `DOMAIN/Service/Provisioning/StateMachines/ServiceProvision_Template` class that calls the method.
++
+[NOTE]
+====
+DOMAIN must be a user-defined Domain and not the locked ManageIQ Domain. If necessary, you can copy the class from the ManageIQ domain into a custom domain.
+====
++
+. Associate method with Automate instance.
+. Create a *Catalog Bundle*, adding each of the catalog items to it. Select the *Service Dialog* you created. Use the instance created in the `DOMAIN/Service/Provisioning/StateMachines/ServiceProvision_Template` class as the *Entry Point*. Check *Display in Catalog* box.
+. Provision a service.
+
+
 [[creating-a-catalog-bundle]]
 ==== Creating a Catalog Bundle
 
@@ -295,6 +276,24 @@ A catalog bundle is created and visible in the *Service Catalog* accordion.
 ====
 You should also create and specify an Entry Point in the `DOMAIN/Service/Provisioning/StateMachines/Methods/CatalogBundle` class for each catalog item that is part of a bundle. If you do not, then the pre and post provision processing will occur for each item in the bundle in addition to processing for the *Catalog Bundle*. To set the entry point, go into each *Catalog Item* and check *Display in Catalog*. Then, you will see the *Entry Point* field.
 ====
+
+[[creating-a-catalog-item]]
+==== Creating a Catalog Item
+
+Create a catalog item for each virtual machine or cloud instance that will be part of the service.
+
+include::common/catalog-item-creation.adoc[]
+
+[[create-playbook-service-catalog-item]]
+===== Creating an Ansible Playbook Service Catalog Item
+
+include::common/create-playbook-service-catalog-item.adoc[]
+
+[[create-tower-catalog-item]]
+===== Creating an Ansible Tower Service Catalog Item
+
+include::common/create-tower-catalog-item.adoc[]
+
 
 [[provisioning-a-service]]
 ===== Provisioning a Service


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1467501

Made the following structural changes in the Catalogs and Services chapter, and a few others changes along the way following the convention -

* Made the text in the 'About Catalogs and Services' section into introductory text
* Changed the text in the 'Terminology' section into a table for better readability and included it as part of the introductory text instead of its own section.
* Promoted the 'Service Dialogs' section to make it as the first sub-section in the 'Catalogs and Services' chapter.
* Promoted the 'Methods' section, it is now the second sub-section in the 'Catalogs and Services' chapter.
* Promoted the 'Creating a Catalog Bundle' section, it is now also its own sub-section under the 'Catalogs' section.

https://github.com/ManageIQ/manageiq_docs/pull/423
Preview: http://file.bne.redhat.com/ssainkar/Red_Hat_CloudForms-4.5-Provisioning_Virtual_Machines_and_Hosts-en-US.pdf

Hey Chris,
Could you please review and merge this PR if everything looks OK? Let me know if you spot anything that needs fixing. These are mainly some structural changes; you will see further updates as part of additional bugs/PRs.
Thanks,
Suyog