### PR TITLE
Document support for the domain user attribute

### DIFF
--- a/auth/active_directory.adoc
+++ b/auth/active_directory.adoc
@@ -77,6 +77,8 @@ Password for user: xxxxxxxx
 
 Update the */etc/sssd/sssd.conf* file as follows:
 
+*Note*: Starting with SSSD version 1.15.2, which will be available in CentOS version 7.4, SSSD will provided the domain name as a user attribute. The below examples show how to set _ldap_user_extra_attrs_ and _user_attributes_ to take advantage of this new feature. If running an appliance built with CentOS version prior to CentOS 7.4 do not include _domainname_ for these attributes.
+
 ----
     [domain/example.com]
     ad_domain = example.com
@@ -90,7 +92,7 @@ Update the */etc/sssd/sssd.conf* file as follows:
     use_fully_qualified_names = True
     fallback_homedir = /home/%d/%u
     access_provider = ad
-=>  ldap_user_extra_attrs = mail, givenname, sn, displayname
+=>  ldap_user_extra_attrs = mail, givenname, sn, displayname, domainname
    
 =>  [sssd]
 =>  domains = example.com
@@ -107,7 +109,7 @@ Update the */etc/sssd/sssd.conf* file as follows:
 =>  [ifp]
 =>  default_domain_suffix = example.com
 =>  allowed_uids = apache, root
-=>  user_attributes = +mail, +givenname, +sn, +displayname
+=>  user_attributes = +mail, +givenname, +sn, +displayname, +domainname
 ----
 
 [[configure-apache]]

--- a/auth/active_directory.adoc
+++ b/auth/active_directory.adoc
@@ -77,7 +77,7 @@ Password for user: xxxxxxxx
 
 Update the */etc/sssd/sssd.conf* file as follows:
 
-*Note*: Starting with SSSD version 1.15.2, which will be available in CentOS version 7.4, SSSD will provided the domain name as a user attribute. The below examples show how to set _ldap_user_extra_attrs_ and _user_attributes_ to take advantage of this new feature. If running an appliance built with CentOS version prior to CentOS 7.4 do not include _domainname_ for these attributes.
+*Note*: Starting with SSSD version 1.15.2, which will be available in CentOS version 7.4, SSSD will provide the domain name as a user attribute. The below examples show how to set _ldap_user_extra_attrs_ and _user_attributes_ to take advantage of this new feature. If running an appliance built with CentOS version prior to CentOS 7.4 do not include _domainname_ for these attributes.
 
 ----
     [domain/example.com]

--- a/auth/ipa_ad_trust.adoc
+++ b/auth/ipa_ad_trust.adoc
@@ -39,7 +39,7 @@ The SSSD configuration file on the IPA Server must be updated to list needed use
 
 Add the following entry to the SSSD configuration file /etc/sssd/sssd.conf
 
-*Note*: Starting with SSSD version 1.15.2, which will be available in CentOS version 7.4, SSSD will provided the domain name as a user attribute. The below examples show how to set _ldap_user_extra_attrs_ and _user_attributes_ to take advantage of this new feature. If running an appliance built with CentOS version prior to CentOS 7.4 do not include _domainname_ for these attributes.
+*Note*: Starting with SSSD version 1.15.2, which will be available in CentOS version 7.4, SSSD will provide the domain name as a user attribute. The below examples show how to set _ldap_user_extra_attrs_ and _user_attributes_ to take advantage of this new feature. If running an appliance built with CentOS version prior to CentOS 7.4 do not include _domainname_ for these attributes.
 
 ```bash
 [ifp]

--- a/auth/ipa_ad_trust.adoc
+++ b/auth/ipa_ad_trust.adoc
@@ -39,9 +39,18 @@ The SSSD configuration file on the IPA Server must be updated to list needed use
 
 Add the following entry to the SSSD configuration file /etc/sssd/sssd.conf
 
+*Note*: Starting with SSSD version 1.15.2, which will be available in CentOS version 7.4, SSSD will provided the domain name as a user attribute. The below examples show how to set _ldap_user_extra_attrs_ and _user_attributes_ to take advantage of this new feature. If running an appliance built with CentOS version prior to CentOS 7.4 do not include _domainname_ for these attributes.
+
 ```bash
 [ifp]
-user_attributes = +mail, +givenname, +sn, +displayname
+user_attributes = +mail, +givenname, +sn, +displayname, +domainname
+```
+
+and update  _ldap_user_extra_attrs_ to include  _domainname_ where appropriate.
+
+```bash
+[domain/example.com]
+ldap_user_extra_attrs = mail, givenname, sn, displayname, domainname
 ```
 
 * DNS Configuration Significance

--- a/auth/ldap.adoc
+++ b/auth/ldap.adoc
@@ -134,7 +134,7 @@ example, customizing the main *[domain/example.com]* section for the particular 
     cache_credentials = True
 =>  entry_cache_timeout = 600
 
-=>  ldap_user_extra_attrs = mail, givenname, sn, displayname
+=>  ldap_user_extra_attrs = mail, givenname, sn, displayname, domainname
 
     [sssd]
 =>  domains = example.com
@@ -152,7 +152,7 @@ example, customizing the main *[domain/example.com]* section for the particular 
 =>  [ifp]
 =>  default_domain_suffix = example.com
 =>  allowed_uids = apache, root
-=>  user_attributes = +mail, +givenname, +sn, +displayname
+=>  user_attributes = +mail, +givenname, +sn, +displayname, +domainname
 ----
 
 ==== Testing SSSD Updates
@@ -176,7 +176,7 @@ systemctl restart sssd
 Example query of user attributes for user evmuser.  This primarily validates the _ldap_user__ attributes of *sssd.conf*.
 
 ----
-# dbus-send --print-reply --system --dest=org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe org.freedesktop.sssd.infopipe.GetUserAttr string:evmuser array:string:mail,givenname,sn,displayname
+# dbus-send --print-reply --system --dest=org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe org.freedesktop.sssd.infopipe.GetUserAttr string:evmuser array:string:mail,givenname,sn,displayname,domainname
 ----
 
 Query groups of user evmuser.  This primarily validates the _ldap_group__ attributes of *sssd.conf*.

--- a/auth/ldap.adoc
+++ b/auth/ldap.adoc
@@ -103,7 +103,7 @@ Configure SSSD based authentication against LDAP via SSL:
 Edit the different sections in */etc/sssd/sssd.conf* for the Appliance as in the following
 example, customizing the main *[domain/example.com]* section for the particular Ldap installation.
 
-*Note*: Starting with SSSD version 1.15.2, which will be available in CentOS version 7.4, SSSD will provided the domain name as a user attribute. The below examples show how to set _ldap_user_extra_attrs_ and _user_attributes_ to take advantage of this new feature. If running an appliance built with CentOS version prior to CentOS 7.4 do not include _domainname_ for these attributes.
+*Note*: Starting with SSSD version 1.15.2, which will be available in CentOS version 7.4, SSSD will provide the domain name as a user attribute. The below examples show how to set _ldap_user_extra_attrs_ and _user_attributes_ to take advantage of this new feature. If running an appliance built with CentOS version prior to CentOS 7.4 do not include _domainname_ for these attributes.
 
 ----
 =>  [domain/example.com]

--- a/auth/ldap.adoc
+++ b/auth/ldap.adoc
@@ -103,6 +103,8 @@ Configure SSSD based authentication against LDAP via SSL:
 Edit the different sections in */etc/sssd/sssd.conf* for the Appliance as in the following
 example, customizing the main *[domain/example.com]* section for the particular Ldap installation.
 
+*Note*: Starting with SSSD version 1.15.2, which will be available in CentOS version 7.4, SSSD will provided the domain name as a user attribute. The below examples show how to set _ldap_user_extra_attrs_ and _user_attributes_ to take advantage of this new feature. If running an appliance built with CentOS version prior to CentOS 7.4 do not include _domainname_ for these attributes.
+
 ----
 =>  [domain/example.com]
     autofs_provider = ldap


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1424618

This PR provides documentation support for PR [15535](https://github.com/ManageIQ/manageiq/pull/15535) in the ManageIQ/manageiq repo. Both should be merged at the same time.

### Note:

This change requires new support in the underlying SSSD code. Updates were
required to provide the domain name when MiQ is configured to use External Authentication (Mode: External (httpd)

The BZs that track this work are:

https://bugzilla.redhat.com/show_bug.cgi?id=1425891
https://bugzilla.redhat.com/show_bug.cgi?id=1455254
The fixes for these BZs are targeted for RHEL 7.4 GA and CentOS 7.4

Therefor this change should not be merged until MiQ appliance builds migrate to RHEL 7.4 GA and CentOS 7.4