### PR TITLE
[FINE] re-added missing -y to yum update command

### DIFF
--- a/doc-General_Configuration/topics/Configuration.adoc
+++ b/doc-General_Configuration/topics/Configuration.adoc
@@ -355,13 +355,13 @@ The following options are available in the *Appliance Updates* section of *Red H
 
 
 |
-            Attempts to register the appliance if it is not already registered. {product-title} subscribes to the `cf-me-5.8-for-rhel-7-rpms rhel-server-rhscl-7-rpms` repositories, and to the products designated by Red Hat product certification for subscription-manager registered appliances. The Red Hat Enterprise Linux channels are enabled by default on registration. In addition, {product-title} automatically checks for updates after registering.
+            Attempts to register the appliance if it is not already registered. {product-title} subscribes to the `rhel-x86_64-server-6-cf-me-3` RHN channel for RHN-registered appliances, and to the products designated by Red Hat product certification for subscription-manager registered appliances. The Red Hat Enterprise Linux channels are enabled by default on registration. In addition, {product-title} automatically checks for updates after registering.
 |
                Apply CFME Update
 
 
 |
-            Applies updates to {product-title} packages only. Specifically, this option runs the `yum update cfme-appliance` command. This command installs every package listed in the dependency tree if it is not already installed. If a specific version of a package is required, that version of the package is installed or upgraded. No other packages, such as PostgreSQL or Red Hat Enterprise Linux, are updated. The appliance may be rebooted automatically during this process.
+            Applies updates to {product-title} packages only. Specifically, this option runs the `yum -y update cfme-appliance` command. This command installs every package listed in the dependency tree if it is not already installed. If a specific version of a package is required, that version of the package is installed or upgraded. No other packages, such as PostgreSQL or Red Hat Enterprise Linux, are updated. The appliance may be rebooted automatically during this process.
 
 
 |===

--- a/doc-General_Configuration/topics/Configuration.adoc
+++ b/doc-General_Configuration/topics/Configuration.adoc
@@ -355,7 +355,7 @@ The following options are available in the *Appliance Updates* section of *Red H
 
 
 |
-            Attempts to register the appliance if it is not already registered. {product-title} subscribes to the `rhel-x86_64-server-6-cf-me-3` RHN channel for RHN-registered appliances, and to the products designated by Red Hat product certification for subscription-manager registered appliances. The Red Hat Enterprise Linux channels are enabled by default on registration. In addition, {product-title} automatically checks for updates after registering.
+            Attempts to register the appliance if it is not already registered. {product-title} subscribes to the `cf-me-5.8-for-rhel-7-rpms rhel-server-rhscl-7-rpms` repositories, and to the products designated by Red Hat product certification for subscription-manager registered appliances. The Red Hat Enterprise Linux channels are enabled by default on registration. In addition, {product-title} automatically checks for updates after registering.
 |
                Apply CFME Update
 


### PR DESCRIPTION
I mistakenly removed the "-y" from the update command in the cherry-pick of #427. Readding.