### PR TITLE
updated repos for euwe - same as in fine except different repo version

### DIFF
--- a/doc-General_Configuration/topics/Configuration.adoc
+++ b/doc-General_Configuration/topics/Configuration.adoc
@@ -355,7 +355,7 @@ The following options are available in the *Appliance Updates* section of *Red H
 
 
 |
-            Attempts to register the appliance if it is not already registered. {product-title} subscribes to the `rhel-x86_64-server-6-cf-me-3` RHN channel for RHN-registered appliances, and to the products designated by Red Hat product certification for subscription-manager registered appliances. The Red Hat Enterprise Linux channels are enabled by default on registration. In addition, {product-title} automatically checks for updates after registering.
+            Attempts to register the appliance if it is not already registered. {product-title} subscribes to the `cf-me-5.7-for-rhel-7-rpms` and `rhel-server-rhscl-7-rpms` repositories, and to the products designated by Red Hat product certification for subscription-manager registered appliances. The Red Hat Enterprise Linux repositories are enabled by default on registration. In addition, {product-title} automatically checks for updates after registering.
 |
                Apply CFME Update
 


### PR DESCRIPTION
Cherry-picking (manually) changes from https://github.com/ManageIQ/manageiq_docs/pull/427 -- the content/change is the same, just different repo version for CF 4.2.