### PR TITLE
Mention ports in Firewall section for findability

### DIFF
--- a/doc-Appliance_Hardening_Guide/cfme/docinfo.xml
+++ b/doc-Appliance_Hardening_Guide/cfme/docinfo.xml
@@ -3,7 +3,7 @@
 <productnumber>4.5</productnumber>
 <subtitle>Instructions on enhancing the security of your Red Hat CloudForms appliances</subtitle>
 <abstract>
-   <para>This guide provides a few procedures to help enhance security to your CloudForms appliances. This includes customizing passwords, restricting unnecessary communication, and encryption key and certificate generation.</para>
+   <para>This guide provides a few procedures to help enhance security to your CloudForms appliances. This includes customizing passwords, restricting unnecessary communication, configuring firewall ports, and encryption key and certificate generation.</para>
    <para>If you have a suggestion for improving this guide or have found an error, please submit a Bugzilla report at <link xlink:href="https://bugzilla.redhat.com/enter_bug.cgi?product=Red%20Hat%20CloudForms%20Management%20Engine">http://bugzilla.redhat.com</link> against <emphasis role="strong">Red Hat CloudForms Management Engine</emphasis> for the <emphasis role="strong">Documentation</emphasis> component. Please provide specific details, such as the section number, guide name, and CloudForms version so we can easily locate the content.</para>
 </abstract>
 <authorgroup id="Author_Group">

--- a/doc-Appliance_Hardening_Guide/miq/docinfo.xml
+++ b/doc-Appliance_Hardening_Guide/miq/docinfo.xml
@@ -3,7 +3,7 @@
 <productnumber>0</productnumber>
 <subtitle>Instructions on enhancing the security of your ManageIQ appliances</subtitle>
 <abstract>
-   <para>This guide provides a few procedures to help enhance security to your ManageIQ appliances. This includes customizing passwords, restricting unnecessary communication, and encryption key and certificate generation.</para>
+   <para>This guide provides a few procedures to help enhance security to your ManageIQ appliances. This includes customizing passwords, restricting unnecessary communication, configuring firewall ports, and encryption key and certificate generation.</para>
 </abstract>
 <authorgroup id="Author_Group">
         <author>

--- a/doc-Appliance_Hardening_Guide/topics/Firewall.adoc
+++ b/doc-Appliance_Hardening_Guide/topics/Firewall.adoc
@@ -1,5 +1,5 @@
 [[_chap_red_hat_cloudforms_security_guide_firewall]]
-=== Configuring the Firewall
+=== Configuring Firewall Ports
 
 A new appliance starts with a few standard ports open:
 


### PR DESCRIPTION
Hi Chris,

I've updated the Firewall section to mention Ports in the title so the content is more easily findable; edited guide abstract to mention ports as well for https://bugzilla.redhat.com/show_bug.cgi?id=1467138.

Preview: http://file.bne.redhat.com/~dayparke/CloudForms/Ports/build/tmp/en-US/html-single/

Please let me know if it looks OK; once merged I'll backport this to all the CF 4.x versions.

Thanks for reviewing!
Dayle
