### PR TITLE
Update API sort reference docs 

### DIFF
--- a/api/appendices/quick_reference.adoc
+++ b/api/appendices/quick_reference.adoc
@@ -45,6 +45,7 @@ of the REST API.
 |Querying Capability |Query Parameters
 |Paging |offset, limit
 |Sorting |sort_by=attr, sort_order=asc\|desc
+| | Can sort by database columns and SQL friendly virtual attributes
 |Filtering |filter[]=...
 |Querying by Tag |i.e. by_tag=/department/finance
 |Expanding Results |expand=<what>, i.e.  expand=resources,tags,service_templates,...

--- a/api/overview/query.adoc
+++ b/api/overview/query.adoc
@@ -31,8 +31,8 @@ attributes=_all_), then all attributes are returned
 returned in the collection and not just the href. See
 <<expanding-collection,Expanding Collection>> below
 |Sorting | |
-| |sort_by=atr1,atr2,... |By which attribute(s) to sort the result by
-| |sort_order=ascending or descending |Order of the sort
+| |sort_by=atr1,atr2,... |By which attribute(s) to sort the result by. SQL friendly virtual attributes are also supported.
+| |sort_order=asc or desc |Order of the sort
 | |sort_options=ignore_case |Option for case insensitive sort
 |=======================================================================
 


### PR DESCRIPTION
This PR updates the sorting docs and does the following:
* Adds mention of the ability to sort by sql friendly virtual attributes
* updates reference of `sort_by=ascending or descending` to `sort_by=asc or desc` which is consistent with the rest of the sorting documentation. 

@miq-bot add_label enhancement 