### PR TITLE
[EUWE] Corrected psql commands in Introducing the Failed Node

### DIFF
--- a/doc-Configuring_High_Availability/topics/Database_Failover.adoc
+++ b/doc-Configuring_High_Availability/topics/Database_Failover.adoc
@@ -112,8 +112,8 @@ Correct this by running the following steps:
 +
 ----
 # psql vmdb_production
-vmdb_production=#select * from repl_nodes
-vmdb_production=#delete from repl_nodes table where id = $cluster_node_id_of_failed node
+vmdb_production=#select * from repl_nodes;
+vmdb_production=#delete from repl_nodes table where id = $cluster_node_id_of_failed node;
 ----
 +
 .. Delete the replication slot information for the failed database node. 
@@ -125,8 +125,8 @@ vmdb_production=#delete from repl_nodes table where id = $cluster_node_id_of_fai
 +
 ----
 # psql vmdb_production
-vmdb_production=#select * from pg_replication_slots
-vmdb_production=#select pg_drop_replication_slot('repmgr_slot_$failed_node_cluster_id')
+vmdb_production=#select * from pg_replication_slots;
+vmdb_production=#select pg_drop_replication_slot('repmgr_slot_$failed_node_cluster_id');
 ----
 +
 .. Reinitialize the standby database as described in xref:configuring_standby_db[] to re-add the node.


### PR DESCRIPTION
Hi Suyog,

I've added in the missing semi-colons to the "psql" commands in the 4.2 HA guide (there were two) -- it looks like we don't have this same procedure in the 4.5 guide.

Please see https://bugzilla.redhat.com/show_bug.cgi?id=1473103 for more info from Jeff Watts.

Preview: http://file.bne.redhat.com/~dayparke/CloudForms/HA-psql/build/tmp/en-US/html-single/#reintroducing_the_failed_node

Please let me know if I've missed anything :)
Thanks for your review!

Cheers,
Dayle