### PR TITLE
Added links to the Red Hat Container Catalog 

### DIFF
--- a/doc-Installing_on_OpenShift_Container_Platform/topics/installation.adoc
+++ b/doc-Installing_on_OpenShift_Container_Platform/topics/installation.adoc
@@ -28,7 +28,9 @@ OpenShift Container Platform 3.5 is required for this installation. Red Hat has 
 
 The {product-title_short} deployment uses three files to create the appliance: `cfme-template.yaml`, which is the {product-title_short} template used for the deployment, and `cfme-pv-example.yaml` and `cfme-pv-app-example.yaml`, two pod volume files. 
 
-These files create the OpenShift pods comprising the appliance, and are available from the Red Hat Container Catalog. To download the files to your system, follow the OpenShift instructions on the *Get this image* page for each of the following images:
+These files create the OpenShift pods comprising the appliance, and are available from the Red Hat Container Catalog.
+
+To download the files to your system, navigate to each of the following pages and click the *Get this image* tab. Select *OpenShift* from the *Choose your platform:* list, then follow the instructions on that page to pull the image:
 
 * https://access.redhat.com/containers/#/registry.access.redhat.com/cloudforms45/cfme-openshift-app[{product-title_short} appliance image]
 * https://access.redhat.com/containers/#/registry.access.redhat.com/cloudforms45/cfme-openshift-memcached[Memcached image]

--- a/doc-Installing_on_OpenShift_Container_Platform/topics/installation.adoc
+++ b/doc-Installing_on_OpenShift_Container_Platform/topics/installation.adoc
@@ -26,7 +26,18 @@ To successfully deploy a {product-title} appliance on OpenShift Container Platfo
 OpenShift Container Platform 3.5 is required for this installation. Red Hat has not tested this procedure with earlier versions of OpenShift Container Platform.
 ====
 
-The {product-title_short} deployment uses three files to create the appliance: `cfme-template.yaml`, which is the {product-title_short} template used for the deployment, and `cfme-pv-example.yaml` and `cfme-pv-app-example.yaml`, two pod volume files. OpenShift Container Platform 3.5 includes these files by default.
+The {product-title_short} deployment uses three files to create the appliance: `cfme-template.yaml`, which is the {product-title_short} template used for the deployment, and `cfme-pv-example.yaml` and `cfme-pv-app-example.yaml`, two pod volume files. 
+
+These files create the OpenShift pods comprising the appliance, and are available from the Red Hat Container Catalog. To download the files to your system, follow the OpenShift instructions on the *Get this image* page for each of the following images:
+
+* https://access.redhat.com/containers/#/registry.access.redhat.com/cloudforms45/cfme-openshift-app[{product-title_short} appliance image]
+* https://access.redhat.com/containers/#/registry.access.redhat.com/cloudforms45/cfme-openshift-memcached[Memcached image]
+* https://access.redhat.com/containers/#/registry.access.redhat.com/cloudforms45/cfme-openshift-postgresql[PostgreSQL image]
+
+
+/////
+OpenShift Container Platform 3.5 includes these files by default.
+/////
 
 ==== Cluster Sizing
 


### PR DESCRIPTION
I've now updated the guide with links to the pod images in the Container Catalog after chatting with the SBR-CFME team to determine the best location to direct customers to.

Suyog, can you please let me know if you think the updates look OK? (Screenshot attached to bug)
Many thanks for reviewing!

https://bugzilla.redhat.com/show_bug.cgi?id=1470493

Cheers,
Dayle