### PR TITLE
Updated the Description field to Name under Access Control user group.

### DIFF
--- a/doc-General_Configuration/topics/Configuration.adoc
+++ b/doc-General_Configuration/topics/Configuration.adoc
@@ -2177,7 +2177,7 @@ To create a user group:
 . From the settings menu, select *Configuration*.
 . Click on the *Access Control* accordion, then click *Groups*.
 . Click image:1847.png[] (*Configuration*), and image:plus_green.png[] (*Add a new Group*) to create a group.
-. Enter a name for the group in the *Description* field. To ensure compatibility with tags, use underscores in place of spaces. For example, {product-title}-`test_group`.
+. Enter a name for the group in the *Name* field. To ensure compatibility with tags, use underscores in place of spaces. For example, {product-title}-`test_group`.
 . Select a role to map to this group.
 . Select the *Project/Tenant* this group must belong to.
 . Select any filters that you want applied to what this group can view in the *Assign Filters* area.


### PR DESCRIPTION
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1471614

@dayleparker Hi Dayle, this is a minor update in the doc as the name of the 'Description' field when creating user groups has changed to 'Name'. Could you please peer review and merge it to master?
Thanks,
Suyog