### PR TITLE
Bz#1467504: Creating a Generic Catalog Item 

### DIFF
--- a/common/create-generic-catalog-item.adoc
+++ b/common/create-generic-catalog-item.adoc
@@ -1,0 +1,21 @@
+. Navigate to menu:Services[Catalogs].
+. Click the *Catalog Items* accordion.
+. Click image:1847.png[](*Configuration*), and then image:1862.png[](*Add a New Catalog Item*).
+. Select *Generic* from the Catalog Item Type list. 
+. In the *Basic Info* subtab:
+.. Type a *Name/Description*.
+.. Check *Display in Catalog* to display the item in the catalog. A *Dialog* will be required if you select *Display in Catalog*.
+.. Choose a *Catalog* to which to add the new item.
+.. Select a *Dialog* from the available options. 
+.. Choose a *Subtype* from the list menu.
+.. Add *Entry Point(NS/Cls/Inst)* options.
+... *Provisioning Entry Point (Domain/NS/Cls/Inst)* requires you to select an Automate instance to run upon provisioning.
+... *Retirement Entry Point (Domain/NS/Cls/Inst)* requires you to select an Automate instance to run upon retirement.
++
+[NOTE]
+========
+The entry point must be a State Machine since the *Provisioning Entry Point* list is filtered to only show State Machine class instances. No other entry points will be available from the *Provisioning Entry Point* field.
+========
++
+. In the *Details* subtab, write a *Long Description* for the catalog item.
+. Click *Add*.

--- a/common/create-playbook-service-catalog-item.adoc
+++ b/common/create-playbook-service-catalog-item.adoc
@@ -1,5 +1,4 @@
 
-Create a catalog item that uses an Ansible Playbook to back it.
 
 [NOTE]
 ====

--- a/common/create-tower-catalog-item.adoc
+++ b/common/create-tower-catalog-item.adoc
@@ -1,4 +1,3 @@
-Create a service catalog item from an Ansible Tower template you can use to execute an Ansible Tower playbook in {product-title}. 
 
 [IMPORTANT]
 ====

--- a/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Catalogs_and_Services.adoc
+++ b/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Catalogs_and_Services.adoc
@@ -300,15 +300,35 @@ Create a catalog item for each virtual machine or cloud instance that will be pa
 
 include::common/catalog-item-creation.adoc[]
 
+[[creating-a-generic-catalog-item]]
+==== Creating a Generic Catalog Item
+
+Create generic catalog items for services non-specific to virtualization or cloud environments. This catalog item type can serve a wide array of needs, from creating a vLAN across a network to accessing virtual machine IP addresses and adding them to a load balancer pool.
+
+include::common/create-generic-catalog-item.adoc[]
+
+
 [[create-playbook-service-catalog-item]]
-===== Creating an Ansible Playbook Service Catalog Item
+==== Creating an Ansible Playbook Service Catalog Item
+
+Create a catalog item that uses an Ansible Playbook to back it.
 
 include::common/create-playbook-service-catalog-item.adoc[]
 
 [[create-tower-catalog-item]]
-===== Creating an Ansible Tower Service Catalog Item
+==== Creating an Ansible Tower Service Catalog Item
+
+Create a service catalog item from an Ansible Tower template you can use to execute an Ansible Tower playbook in {product-title}. 
 
 include::common/create-tower-catalog-item.adoc[]
+
+
+[[provisioning-a-service]]
+===== Provisioning a Service
+
+include::common/catalog-order.adoc[]
+
+The parameters are passed to the children based on the method tied to the choices made in the dialog.
 
 
 [[provisioning-a-service]]

--- a/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Catalogs_and_Services.adoc
+++ b/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Catalogs_and_Services.adoc
@@ -331,12 +331,7 @@ include::common/catalog-order.adoc[]
 The parameters are passed to the children based on the method tied to the choices made in the dialog.
 
 
-[[provisioning-a-service]]
-===== Provisioning a Service
 
-include::common/catalog-order.adoc[]
-
-The parameters are passed to the children based on the method tied to the choices made in the dialog.
 
 
 


### PR DESCRIPTION
Hey Suyog,

I've added the required procedure on adding a generic catalog item Provisioning VMs guide, which you can find in the included files. While working on this, I did make an additional change of moving this item, and those for Ansible Playbook and Ansible Tower catalog items up a level in the index. My rational is that, since each of these is really its own unique workflow, they shouldn't be nested as subtopics under Creating a Catalog Item (that deal with different providers).

Let me know what you think.

-Chris