### PR TITLE
add missing character to install instruction

### DIFF
--- a/doc-Installing_on_VMware_vSphere/topics/additional_configuration.adoc
+++ b/doc-Installing_on_VMware_vSphere/topics/additional_configuration.adoc
@@ -22,7 +22,7 @@ If you do not already have a login ID to VMware, then you will need to create on
 # cd /root
 # tar -xvf VMware-vix-disklib-5.5.0-1284542.x86_64.tar.gz
 # cd vmware-vix-disklib-distrib
-# /vmware-install.pl
+# ./vmware-install.pl
 ----
 +
 . Accept the defaults during the installation:


### PR DESCRIPTION
Hey Dayle,

Quick one here. I've added the missing "." to the final command in the installation procedure.

-Chris 