### PR TITLE
add procedure on displaying report in full screen

### DIFF
--- a/doc-Monitoring_Alerts_and_Reporting/topics/Showing_a_Report_in_Full_Screen.adoc
+++ b/doc-Monitoring_Alerts_and_Reporting/topics/Showing_a_Report_in_Full_Screen.adoc
@@ -1,7 +1,7 @@
 [[showing-a-report-in-full-screen]]
 ==== Showing a Report in Full Screen
 
-View the report in full screen to zoom into examine report details.
+View the report in full screen to examine report details.
 From full screen, you can also print the chart that accompanies a report. 
 
 . Navigate to menu:Cloud Intelligence[Reports].

--- a/doc-Monitoring_Alerts_and_Reporting/topics/Showing_a_Report_in_Full_Screen.adoc
+++ b/doc-Monitoring_Alerts_and_Reporting/topics/Showing_a_Report_in_Full_Screen.adoc
@@ -1,5 +1,14 @@
 [[showing-a-report-in-full-screen]]
 ==== Showing a Report in Full Screen
 
-View the report in full screen to zoom into the report screen.
+View the report in full screen to zoom into examine report details.
 From full screen, you can also print the chart that accompanies a report. 
+
+. Navigate to menu:Cloud Intelligence[Reports].
+. Click the menu:Reports[All Reports] accordion and select the report that you want to view.
+. Click the *Saved Reports* tab and select a report. 
+. On the *Saved Report* detail screen, click image:1847.png[] (*Configuration*), and click image:2133.png[] (*Show full screen Report*).
+
+The report will appear in full screen view. Click back on your browser to return to the reports explorer. 
+
+


### PR DESCRIPTION
Hey Dayle,

I've added the procedure on opening a report in full screen, requested in section 3.2.4 of BZ1309713. 

The only remaining item on that BZ is populated the Operational Type Alerts table, which I'm still trying to get some feedback on. So once this is merged I'd like to move the BZ to verified and track updates to that table in a new BZ, so please feel free to move to verified.

-Chris