### PR TITLE
[FINE] Removing 'deploy from external DB' section

### DIFF
--- a/doc-Installing_on_OpenShift_Container_Platform/topics/installation.adoc
+++ b/doc-Installing_on_OpenShift_Container_Platform/topics/installation.adoc
@@ -212,28 +212,6 @@ $ oc new-app --template=cloudforms -p DATABASE_VOLUME_CAPACITY=2Gi,MEMORY_POSTGR
 The `APPLICATION_DOMAIN` parameter specifies the hostname used to reach the {product-title_short} application, which eventually constructs the route to the {product-title_short} pod. If you do not specify the `APPLICATION_DOMAIN` parameter, the {product-title_short} application will not be accessible after the deployment; however, this can be fixed by changing the route. For more information on OpenShift template parameters, see the https://access.redhat.com/documentation/en-us/openshift_container_platform/3.5/html-single/developer_guide/#dev-guide-templates[OpenShift Container Platform Developer Guide].
 ====
 
-[[deploying-the-appliance-external-db]]
-==== Deploying the {product-title_short} Appliance Using an External Database
-
-Before attempting to deploy {product-title_short} using an external database deployment, ensure the following conditions are satisfied:
-
-* Your OpenShift cluster can access the external PostgreSQL server
-* The {product-title_short} user, password, and role have been created on the external PostgreSQL server
-* The intended {product-title_short} database is created, and ownership has been assigned to the {product-title_short} user
-
-To deploy the appliance:
-
-. Import the {product-title_short} external database template:
-+
-----
-$ oc create -f templates/cfme-template-ext-db.yaml
-----
-+
-. Launch the deployment with the following command. The database server IP address is required, and the other settings must match your remote PostgreSQL server.
-+
-----
-$ oc new-app --template=cloudforms-ext-db -p DATABASE_IP=<server_ip> -p DATABASE_USER=<user> -p DATABASE_PASSWORD=<password> -p DATABASE_NAME=<database_name>
-----
 
 [[verifying-the-configuration]]
 === Verifying the Configuration


### PR DESCRIPTION
Hi Andrew,

I've removed 'Deploying the CloudForms Appliance Using an External Database' from the _fine_ branch as it's not supported in CloudForms 4.5.1 (as we learned via feedback from Satoe-san in QE). As this will be supported in CFME 5.8.2; left the content in master for publishing with next release.

Would you mind merging this PR please? I will republish the guide to the Portal afterward.

Also, I wonder if we should create a BZ to remind us to include the content again for 5.8.2, as having it in master will only get it into the upcoming CloudForms 4.6 guides, IIUC. What do you think?

Thank you,
Dayle