### PR TITLE
Bz1473283 - Mention need to use DNS resolvable hostname in credentials for VMware provider on IPv6 network

### DIFF
--- a/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
+++ b/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
@@ -84,7 +84,7 @@ Alternately, you can refresh some or all repositories from the list view:
 
 [IMPORTANT]
 =====
-If both {product_title_short} and a VMware provider are located in the same IPv6-only network, use a DNS-resolvable hostname for the VMware provider in the _vCenter Host_ field when adding credentials.
+If both {product-title_short} and a VMware provider are located in the same IPv6-only network, use a DNS-resolvable hostname for the VMware provider in the _vCenter Host_ field when adding credentials.
 =====
 
 . Navigate to menu:Automation[Ansible > Credentials].

--- a/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
+++ b/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
@@ -84,7 +84,7 @@ Alternately, you can refresh some or all repositories from the list view:
 
 [IMPORTANT]
 =====
-If both {product-title_short} and a VMware provider are located in the same IPv6-only network, use a DNS-resolvable hostname for the VMware provider in the _vCenter Host_ field when adding credentials.
+If both {product-title_short} and a VMware provider are located in the same IPv6-only network, use a DNS-resolvable hostname for the VMware provider in the *vCenter Host* field when adding credentials.
 =====
 
 . Navigate to menu:Automation[Ansible > Credentials].

--- a/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
+++ b/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
@@ -84,7 +84,7 @@ Alternately, you can refresh some or all repositories from the list view:
 
 [IMPORTANT]
 =====
-If both {product_title_short} and a VMware provider are located in the same IPv6-only network, use a resolvable hostname for the VMware provider in the _vCenter Host_ field when adding credentials.
+If both {product_title_short} and a VMware provider are located in the same IPv6-only network, use a DNS-resolvable hostname for the VMware provider in the _vCenter Host_ field when adding credentials.
 =====
 
 . Navigate to menu:Automation[Ansible > Credentials].

--- a/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
+++ b/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
@@ -82,6 +82,11 @@ Alternately, you can refresh some or all repositories from the list view:
 === Adding Credentials
 {product-title} can store credentials used by playbooks. Credentials saved in {product-title_short} are matched and executed with a playbook when run.   
 
+[IMPORTANT]
+=====
+If both {product_title_short} and a VMware provider are located in the same IPv6-only network, use a resolvable hostname for the VMware provider in the _vCenter Host_ field when adding credentials.
+=====
+
 . Navigate to menu:Automation[Ansible > Credentials].
 . Click  image:1847.png[Configuration] (*Configuration*), then  image:1862.png[Add a New Credential] (*Add a New Credential*).
 . Provide a *Name* for the credential.


### PR DESCRIPTION
Hey Dayle,

I added an Important admonition here to call attendtion to the problem dscribed in the BZ. Please let me know what you think. 

-Chris