### PR TITLE
[BZ1455568] Add Enable Server Role procedure and add note about establishing network id

### DIFF
--- a/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
+++ b/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
@@ -49,6 +49,12 @@ A table of all workers and current status will appear from which you can confirm
 === Adding a Playbook Repository
 Add a repository so that {product-title} can discover and make available your playbooks.
  
+[NOTE]
+
+====
+Configure your {product-title_short] appliance network identity (hostname/IP address) before adding Ansible playbook repositories. Restart the `evmserverd` service after changing the hostname or IP address to ensure repositories add properly.
+====
+ 
 . Navigate to menu:Automation[Ansible > Repositories].
 . Click *Add*.
 . Provide a Repository Name in the *Name* field. 

--- a/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
+++ b/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
@@ -11,11 +11,6 @@ In {product-title}, an automation management provider is a management tool that 
 
 *Ansible Tower* is a management tool integrated with {product-title_short}, designed to help automate infrastructure operations utilizing existing Ansible Tower providers in your inventory. {product-title_short} allows you to execute Ansible Tower jobs using service catalogs and Automate. Using Ansible Tower, you can schedule Ansible playbook runs and monitor current and historical results, allowing for troubleshooting or identification of issues before they occur.
 
-[NOTE]
-====
-In {product-title}, the Ansible role is disabled by default. Navigate to the settings menu, then *Configuration* &#8594; *Settings* and select the desired server under *Zones*. Set the *Server Role* for *Embedded Ansible* to *On* to enable the role.
-====
-
 
 [[ansible-inside]]
 == Ansible
@@ -32,9 +27,24 @@ Ranging from simple to complex tasks, Ansible playbooks can support cloud manage
 
 Ansible is built into {product-title_short} so there is nothing to install. The basic workflow when using Ansible in {product-title} is as follows:
 
+* Enable the *Embedded Ansible* server role.
 * Add a source control repository that contains your playbooks.
 * Establish credentials with your inventory. 
 * Back your services, alerts and policies using available playbooks. 
+
+
+[[enabling-embedded-ansible-server-role]]
+=== Enabling the Embedded Ansible Server Role
+In {product-title}, the Ansible role is disabled by default. Enable the server role to utilize Ansible Automation Inside. 
+
+[NOTE]
+====
+Configure your {product-title_short} appliance network identity (hostname/IP address) before enabling the Ansible server role. Restart the `evmserverd` service on the appliance with the enabled Ansible role after making any changes to the hostname or IP address.
+====
+
+. Navigate to the settings menu, then *Configuration* &#8594; *Settings*.
+. Select the desired server under *Zones*.
+. Set the *Server Role* for *Embedded Ansible* to *On*. 
 
 [[verifying-embedded-ansible-worker-state]]
 === Verifying the Embedded Ansible Worker State
@@ -52,7 +62,7 @@ Add a repository so that {product-title} can discover and make available your pl
 [NOTE]
 
 ====
-Configure your {product-title_short] appliance network identity (hostname/IP address) before adding Ansible playbook repositories. Restart the `evmserverd` service after changing the hostname or IP address to ensure repositories add properly.
+Configure your {product-title_short} appliance network identity (hostname/IP address) before adding Ansible playbook repositories. Restart the `evmserverd` service after changing the hostname or IP address to ensure repositories add properly.
 ====
  
 . Navigate to menu:Automation[Ansible > Repositories].

--- a/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
+++ b/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
@@ -27,15 +27,15 @@ Ranging from simple to complex tasks, Ansible playbooks can support cloud manage
 
 Ansible is built into {product-title_short} so there is nothing to install. The basic workflow when using Ansible in {product-title} is as follows:
 
-* Enable the *Embedded Ansible* server role.
-* Add a source control repository that contains your playbooks.
-* Establish credentials with your inventory. 
-* Back your services, alerts and policies using available playbooks. 
+. Enable the *Embedded Ansible* server role.
+. Add a source control repository that contains your playbooks.
+. Establish credentials with your inventory. 
+. Back your services, alerts and policies using available playbooks. 
 
 
 [[enabling-embedded-ansible-server-role]]
 === Enabling the Embedded Ansible Server Role
-In {product-title}, the Ansible role is disabled by default. Enable the server role to utilize Ansible Automation Inside. 
+In {product-title}, the *Embedded Ansible* role is disabled by default. Enable this server role to utilize Ansible Automation Inside. 
 
 [NOTE]
 ====

--- a/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
+++ b/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
@@ -59,11 +59,6 @@ A table of all workers and current status will appear from which you can confirm
 === Adding a Playbook Repository
 Add a repository so that {product-title} can discover and make available your playbooks.
  
-[NOTE]
-
-====
-Configure your {product-title_short} appliance network identity (hostname/IP address) before adding Ansible playbook repositories. Restart the `evmserverd` service after changing the hostname or IP address to ensure repositories add properly.
-====
  
 . Navigate to menu:Automation[Ansible > Repositories].
 . Click *Add*.

--- a/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
+++ b/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
@@ -48,7 +48,7 @@ Configure your {product-title_short} appliance network identity (hostname/IP add
 
 [[verifying-embedded-ansible-worker-state]]
 === Verifying the Embedded Ansible Worker State
-Verify that the embedded Ansible worker has started to utilize its features. 
+Verify that the Embedded Ansible worker has started to utilize its features. 
 
 . Navigate to the settings menu, then *Configuration* &#8594; *Diagnostics* and click on the desired server.
 . Click on the *Workers* tab. 

--- a/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
+++ b/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
@@ -39,7 +39,7 @@ In {product-title}, the *Embedded Ansible* role is disabled by default. Enable t
 
 [NOTE]
 ====
-Configure your {product-title_short} appliance network identity (hostname/IP address) before enabling the Ansible server role. Restart the `evmserverd` service on the appliance with the enabled Ansible role after making any changes to the hostname or IP address.
+Configure your {product-title_short} appliance network identity (hostname/IP address) before enabling the Embedded Ansible server role. Restart the `evmserverd` service on the appliance with the enabled Embedded Ansible server role after making any changes to the hostname or IP address.
 ====
 
 . Navigate to the settings menu, then *Configuration* &#8594; *Settings*.


### PR DESCRIPTION
Hi Dayle,

Here's the PR on enabling the Ansible Server role and a note admonition calling out best practice of first setting up the network ID for the appliance. Let me know what you think.

-Chris