### PR TITLE
Optional attribute to specify OpenStack domain using ReST API

### DIFF
--- a/api/appendices/resource_attributes.adoc
+++ b/api/appendices/resource_attributes.adoc
@@ -442,6 +442,7 @@ POST /api/providers
 |=====================
 | Attribute | Type | Description
 | api_version | string | API Version for communicating with the Provider
+| uid_ems | string | Domain for OpenStack provider. Required when "api_version" is "v3"
 | certificate_authority | string | CA for the Provider
 | connection_configurations | array | Endpoints for the Provider
 | credentials | hash | Credentials to use for communicating with the Provider, see link:../reference/providers.html[Provider Support] for examples


### PR DESCRIPTION
When adding OpenStack provider with `api_version` as `v3` a domain ID
needs to be specified using the field `uid_ems`.

To list domains in OpenStack use,
~~~
openstack domain list
~~~

Output
~~~
+----------------------------------+---------+---------+--------------------+
| ID                               | Name    | Enabled | Description        |
+----------------------------------+---------+---------+--------------------+
| 71cff74aa5504a399c03d1b25ca72fe4 | domain1 | True    |                    |
| cd8ab0580abd4620bfd87319215a90f2 | domain2 | True    |                    |
| default                          | Default | True    | The default domain |
+----------------------------------+---------+---------+--------------------+
~~~

Sample JSON load,
~~~
{
  "type"      : "ManageIQ::Providers::Openstack::CloudManager",
  "name"      : "testo",
  "hostname"  : "testo",
  "ipaddress" : "10.61.8.133",
  "api_version": "v3",
  "uid_ems": "default",
  "security_protocol": "non-ssl",
  "credentials" : {
      "userid"    : "admin",
      "password"  : "superpasswd"
  }
}
~~~

Signed-off-by: Sachin Patil <psachin@redhat.com>