### PR TITLE
conditionalize configuration file so that database config only appear…

### DIFF
--- a/common/configuration.adoc
+++ b/common/configuration.adoc
@@ -33,9 +33,9 @@ The {product-title} appliance console automatically logs out after five minutes 
 
 [[advanced-configuration-settings]]
 === Advanced Configuration Settings
-
 include::configuration-advanced.adoc[]
 
+ifdef::cfme[]
 [[configuring_a_database]]
 === Configuring a Database for {product-title}
 
@@ -92,6 +92,7 @@ All {product-title_short} appliances in a multi-region deployment must use the s
 . Confirm the configuration if prompted.
 
 {product-title} will then configure the external database.
+endif::cfme[]
 
 [[configuring-a-worker-appliance]]
 === Configuring a Worker Appliance


### PR DESCRIPTION
…s in CFME docs

Hey Dayle,

Would you mind taking a look at this PR? I've set up the configuration.adoc so that section 2.3 only appears in CFME docs, as ManageIQ builds have an internal database. Please let me know if you have any questions.

-Chris