### PR TITLE
add info on TTL to playbook catalog item creation procedure

### DIFF
--- a/common/create-playbook-service-catalog-item.adoc
+++ b/common/create-playbook-service-catalog-item.adoc
@@ -19,7 +19,7 @@
 .. Assign the appropriate *Machine Credentials* from the drop-down list. 
 .. Add *Cloud* or *Network Credentials* from the drop-down lists. 
 .. Choose the *Host* against which to run the service item. 
-.. Set the *Max TTL* in minutes. The *Time To Live (TTL)* field allows you to set the maximum execution time for the playbook to run. 
+.. Set the *Max TTL* in minutes. The Time To Live (TTL) field allows you to set the maximum execution time for the playbook to run. 
 .. Use the *Escalate Privilege* toggle switch to enable user privilege escalation if called for in credentials during the playbook run.
 .. Choose a *Verbosity* value to set the debug level for playbook execution.
 .. Add key value pairs for *Variables* and their corresponding *Default Values*. 
@@ -30,7 +30,7 @@
 .. Assign the appropriate *Machine Credentials* from the drop-down list. 
 .. Add *Cloud* or *Network Credentials* from the drop-down lists. 
 .. Choose the *Host* against which to run the service item. 
-.. Set the *Max TTL* in minutes. The *Time To Live (TTL)* field allows you to set the maximum execution time for the playbook to run. 
+.. Set the *Max TTL* in minutes. The Time To Live (TTL) field allows you to set the maximum execution time for the playbook to run. 
 .. Use the *Escalate Privilege* toggle switch to enable user privilege escalation if called for in credentials during the playbook run. 
 .. Choose a *Verbosity* value to set the debug level for playbook execution. 
 .. Add key value pairs for *Variables* and their corresponding *Default Values*. 

--- a/common/create-playbook-service-catalog-item.adoc
+++ b/common/create-playbook-service-catalog-item.adoc
@@ -19,6 +19,7 @@
 .. Assign the appropriate *Machine Credentials* from the drop-down list. 
 .. Add *Cloud* or *Network Credentials* from the drop-down lists. 
 .. Choose the *Host* against which to run the service item. 
+.. Set the *Max TTL* in minutes. The *Time To Live (TTL)* field allows you to set the maximum execution time for the playbook to run. 
 .. Use the *Escalate Privilege* toggle switch to enable user privilege escalation if called for in credentials during the playbook run.
 .. Choose a *Verbosity* value to set the debug level for playbook execution.
 .. Add key value pairs for *Variables* and their corresponding *Default Values*. 
@@ -29,6 +30,7 @@
 .. Assign the appropriate *Machine Credentials* from the drop-down list. 
 .. Add *Cloud* or *Network Credentials* from the drop-down lists. 
 .. Choose the *Host* against which to run the service item. 
+.. Set the *Max TTL* in minutes. The *Time To Live (TTL)* field allows you to set the maximum execution time for the playbook to run. 
 .. Use the *Escalate Privilege* toggle switch to enable user privilege escalation if called for in credentials during the playbook run. 
 .. Choose a *Verbosity* value to set the debug level for playbook execution. 
 .. Add key value pairs for *Variables* and their corresponding *Default Values*. 


### PR DESCRIPTION
Hey Suyog,

I've added some info here regarding the new TTL field for ansible playbook catalog items. I decided to keep the description brief, and in line with the procedural step rather than calling it out in a note. Also, I kept the description rather brief, as I think this is more or less all the user needs to know. 

Let me know what you think.

-Chris