### PR TITLE
Bz1497892 installation content 4.6

### DIFF
--- a/common/cfme-obtaining-the-appliance.adoc
+++ b/common/cfme-obtaining-the-appliance.adoc
@@ -1,5 +1,5 @@
 . Go to link:https://access.redhat.com[access.redhat.com] and log in to the Red Hat Customer Portal using your customer account details.
 . Click *Downloads* in the menu bar.
 . Click *A-Z* to sort the product downloads alphabetically.
-. Click *Red Hat CloudForms* to access the product download page. The latest version of each download displays by default.
-. From the list of installers and images under *Product Software*, choose *OpenStack Virtual Appliance* option with the latest version and click *Download Now*.
+. Click *Red Hat CloudForms* to access the product download page.
+. From the list of installers and images, click the *Download Now* link for *CFME OpenStack Virtual Appliance*.

--- a/common/configuration.adoc
+++ b/common/configuration.adoc
@@ -1,17 +1,15 @@
 [[Configuring-cloudforms]]
 == Configuring {product-title}
 
-Although the {product-title} appliance comes configured to be integrated immediately into your environment, you can make some changes to its configuration.
+After installing {product-title_short} and running it for the first time, you must perform some basic configuration. To configure {product-title_short}, you must at a minimum:
 
-[NOTE]
-====
-The {product-title} appliance is intended to have minimal configuration options.
-====
+. Add a disk to the infrastructure hosting your appliance.
+. Configure the database. 
 
-[[changing-configuration-settings]]
-=== Changing Configuration Settings
+You must configure the {product-title_short} appliance using the internal appliance console.
 
-The following procedure describes how to make changes to the configuration settings on the {product-title} appliance.
+[[accessing-appliance-console]]
+=== Accessing the Appliance Console
 
 . Start the appliance and open a terminal console.
 ifdef::login[]
@@ -28,20 +26,17 @@ endif::ssh[]
 
 [NOTE]
 ====
-The {product-title} appliance console automatically logs out after five minutes of inactivity.
+The {product-title_short} appliance console automatically logs out after five minutes of inactivity.
 ====
 
-[[advanced-configuration-settings]]
-=== Advanced Configuration Settings
-include::configuration-advanced.adoc[]
 
 ifdef::cfme[]
 [[configuring_a_database]]
-=== Configuring a Database for {product-title}
+=== Configuring a Database
 
-Before using {product-title}, configure the database options for it. {product-title} provides two options for database configuration:
+{product-title_short} uses a database to store information about the environment. Before using {product-title_short}, configure the database options for it; {product-title_short} provides the following two options for database configuration:
 
-* Install an internal PostgreSQL database to the appliance
+* Install an internal PostgreSQL database to the appliance 
 * Configure the appliance to use an external PostgreSQL database
 
 [[configuring-an-internal-database]]

--- a/common/configuration.adoc
+++ b/common/configuration.adoc
@@ -6,7 +6,7 @@ After installing {product-title_short} and running it for the first time, you mu
 . Add a disk to the infrastructure hosting your appliance.
 . Configure the database. 
 
-You must configure the {product-title_short} appliance using the internal appliance console.
+Configure the {product-title_short} appliance using the internal appliance console.
 
 [[accessing-appliance-console]]
 === Accessing the Appliance Console

--- a/doc-Installing_on_AWS/topics/installation.adoc
+++ b/doc-Installing_on_AWS/topics/installation.adoc
@@ -1,12 +1,13 @@
 [[installing-cloudforms-aws]]
 == Installing {product-title}
 
-{product-title} is able to be installed and ready to configure in a few quick steps. After downloading {product-title} as a virtual machine image template from the Red Hat Customer Portal, the installation process takes you through the steps of uploading the appliance to a supported virtualization or cloud provider.
+Installing {product-title} consists of the following steps:
 
-[IMPORTANT]
-====
-After installing the {product-title} appliance, you must configure the database for {product-title}. See xref:configuring_a_database[].
-====
+. Downloading the appliance for your environment as a virtual machine image template.
+. Setting up a virtual machine based on the appliance.
+. Configuring the {product-title_short} appliance.
+
+After you have completed all the procedures in this guide, you will have a working environment on which additional customizations and configurations can be performed.
 
 ifdef::miq[]
 [[obtaining-the-appliance]]
@@ -25,8 +26,8 @@ ifdef::cfme[]
 . Go to link:https://access.redhat.com[access.redhat.com] and log in to the Red Hat Customer Portal using your customer account details.
 . Click *Downloads* in the menu bar.
 . Click *A-Z* to sort the product downloads alphabetically.
-. Click menu:Red Hat CloudForms[Download Latest] to access the product download page.
-. From the list of installers and images, select the *CFME EC2 Virtual Appliance* download link.
+. Click *Red Hat CloudForms* to access the product download page.
+. From the list of installers and images, click the *Download Now* link for *CFME EC2 Virtual Appliance*.
 endif::cfme[]
 
 [[uploading-the-appliance-on-amazon-ec2]]

--- a/doc-Installing_on_Google_Compute_Engine/topics/installation.adoc
+++ b/doc-Installing_on_Google_Compute_Engine/topics/installation.adoc
@@ -1,12 +1,13 @@
 [[installing-cloudforms]]
 == Installing {product-title}
 
-{product-title} is able to be installed and ready to configure in a few quick steps. After downloading {product-title} as a virtual machine image template from the Red Hat Customer Portal, the installation process takes you through the steps of uploading the appliance to a supported virtualization or cloud provider.
+Installing {product-title} consists of the following steps:
 
-[IMPORTANT]
-======
-After installing the {product-title} appliance, you must configure the database for {product-title}. See xref:configuring_a_database[].
-======
+. Downloading the appliance for your environment as a virtual machine image template.
+. Setting up a virtual machine based on the appliance.
+. Configuring the {product-title_short} appliance.
+
+After you have completed all the procedures in this guide, you will have a working environment on which additional customizations and configurations can be performed.
 
 ifdef::miq[]
 [[obtaining-the-appliance]]
@@ -25,8 +26,8 @@ ifdef::cfme[]
 . Go to link:https://access.redhat.com[access.redhat.com] and log in to the Red Hat Customer Portal using your customer account details.
 . Click *Downloads* in the menu bar.
 . Click *A-Z* to sort the product downloads alphabetically.
-. Click menu:Red Hat CloudForms[Download Latest] to access the product download page.
-. From the list of installers and images, select the *Google Compute Engine* download link.
+. Click *Red Hat CloudForms* to access the product download page.
+. From the list of installers and images, click the *Download Now* link for *Google Compute Engine*.
 endif::cfme[]
 
 [[uploading-the-appliance-on-google-compute-engine]]

--- a/doc-Installing_on_Microsoft_Azure/topics/installation.adoc
+++ b/doc-Installing_on_Microsoft_Azure/topics/installation.adoc
@@ -1,12 +1,13 @@
 [[installing-cloudforms]]
 == Installing {product-title}
 
-{product-title} can be installed and ready to configure in a few quick steps. After downloading {product-title} as a virtual machine image template from the Red Hat Customer Portal, the following process takes you through the steps of uploading the {product-title} appliance to Microsoft Azure.
+Installing {product-title} consists of the following steps:
 
-[IMPORTANT]
-====
-After uploading the {product-title} appliance, you must configure the database for {product-title}; see xref:configuring_a_database[Configuring a Database for {product-title}].
-====
+. Downloading the appliance for your environment as a virtual machine image template.
+. Setting up a virtual machine based on the appliance.
+. Configuring the {product-title_short} appliance.
+
+After you have completed all the procedures in this guide, you will have a working environment on which additional customizations and configurations can be performed.
 
 ifdef::miq[]
 [[obtaining-the-appliance]]
@@ -25,8 +26,8 @@ ifdef::cfme[]
 . Go to link:https://access.redhat.com[access.redhat.com] and log in to the Red Hat Customer Portal using your customer account details.
 . Click *Downloads* in the menu bar.
 . Click *A-Z* to sort the product downloads alphabetically.
-. Click menu:Red Hat CloudForms[Download Latest] to access the product download page.
-. From the list of installers and images, select the {product-title} appliance specified for Microsoft Azure download link.
+. Click *Red Hat CloudForms* to access the product download page.
+. From the list of installers and images, click the *Download Now* link for *CFME Azure Virtual Appliance*.
 endif::cfme[]
 
 

--- a/doc-Installing_on_Red_Hat_Enterprise_Linux_OpenStack_Platform/topics/installation.adoc
+++ b/doc-Installing_on_Red_Hat_Enterprise_Linux_OpenStack_Platform/topics/installation.adoc
@@ -1,12 +1,13 @@
 [[installing-cloudforms]]
 == Installing {product-title}
 
-{product-title} is able to be installed and ready to configure in a few quick steps. After downloading {product-title} as a virtual machine image template from the Red Hat Customer Portal, the installation process takes you through the steps of uploading the appliance to a supported virtualization or cloud provider.
+Installing {product-title} consists of the following steps:
 
-[IMPORTANT]
-=======
-After installing the {product-title} appliance, you must configure the database for {product-title}. See xref:configuring_a_database[].
-=======
+. Downloading the appliance for your environment as a virtual machine image template.
+. Setting up a virtual machine based on the appliance.
+. Configuring the {product-title_short} appliance.
+
+After you have completed all the procedures in this guide, you will have a working environment on which additional customizations and configurations can be performed.
 
 ifdef::miq[]
 [[obtaining-the-appliance]]

--- a/doc-Installing_on_Red_Hat_Virtualization/topics/installation.adoc
+++ b/doc-Installing_on_Red_Hat_Virtualization/topics/installation.adoc
@@ -1,12 +1,27 @@
 [[installing-cloudforms]]
 == Installing {product-title}
 
+[ADD INTRO] 
+
+* brief overview of what installing CloudForms entails. Namely, downloading the appliance for your environment, setting up a virtual machine based on the appliance, then configuring it.
+
+Installing {product-title} comprises of the following steps:
+
+. Downloading the appliance as a virtual machine image template. 
+
+
+* let users know where they will end up at the end of the guide - with a working environment on which additional customizations and configurations can be performed.
+
+////
+
 {product-title} is able to be installed and ready to configure in a few quick steps. After downloading {product-title} as a virtual machine image template from the Red Hat Customer Portal, the installation process takes you through the steps of uploading the appliance to a Red Hat Virtualization environment.
 
 [IMPORTANT]
 =====
 After installing the {product-title} appliance, you must configure the database for {product-title}. See xref:configuring_a_database[].
 =====
+
+////
 
 ifdef::miq[]
 [[obtaining-the-appliance]]

--- a/doc-Installing_on_Red_Hat_Virtualization/topics/installation.adoc
+++ b/doc-Installing_on_Red_Hat_Virtualization/topics/installation.adoc
@@ -1,27 +1,14 @@
 [[installing-cloudforms]]
 == Installing {product-title}
 
-[ADD INTRO] 
+Installing {product-title} consists of the following steps:
 
-* brief overview of what installing CloudForms entails. Namely, downloading the appliance for your environment, setting up a virtual machine based on the appliance, then configuring it.
+. Downloading the appliance for your environment as a virtual machine image template.
+. Setting up a virtual machine based on the appliance.
+. Configuring the {product-title_short} appliance.
 
-Installing {product-title} comprises of the following steps:
+After you have completed all the procedures in this guide, you will have a working environment on which additional customizations and configurations can be performed.
 
-. Downloading the appliance as a virtual machine image template. 
-
-
-* let users know where they will end up at the end of the guide - with a working environment on which additional customizations and configurations can be performed.
-
-////
-
-{product-title} is able to be installed and ready to configure in a few quick steps. After downloading {product-title} as a virtual machine image template from the Red Hat Customer Portal, the installation process takes you through the steps of uploading the appliance to a Red Hat Virtualization environment.
-
-[IMPORTANT]
-=====
-After installing the {product-title} appliance, you must configure the database for {product-title}. See xref:configuring_a_database[].
-=====
-
-////
 
 ifdef::miq[]
 [[obtaining-the-appliance]]
@@ -44,8 +31,8 @@ The following procedure outlines how to obtain a copy of the appliance from the 
 . Go to link:https://access.redhat.com[access.redhat.com] and log in to the Red Hat Customer Portal using your customer account details.
 . Click *Downloads* in the menu bar.
 . Click *A-Z* to sort the product downloads alphabetically.
-. Click menu:Red Hat CloudForms[Download Latest] to access the product download page.
-. From the list of installers and images, select the *CFME Red Hat Virtual Appliance* download link.
+. Click *Red Hat CloudForms* to access the product download page.
+. From the list of installers and images, click the *Download Now* link for *CFME Red Hat Virtual Appliance*.
 endif::cfme[]
 
 [[uploading-the-appliance-on-red-hat-virtualization]]

--- a/doc-Installing_on_VMware_vSphere/topics/additional_configuration.adoc
+++ b/doc-Installing_on_VMware_vSphere/topics/additional_configuration.adoc
@@ -4,7 +4,7 @@
 [[installing-vmware-vddk]]
 === Installing VMware VDDK on {product-title}
 
-Execution of SmartState Analysis on virtual machines within a VMware environment requires the Virtual Disk Development Kit (VDDK). {product-title} supports VDDK 5.5.
+Execution of SmartState analysis on virtual machines within a VMware environment requires the Virtual Disk Development Kit (VDDK). {product-title} supports VDDK 5.5.
 
 . Download `VDDK 5.5` (`VMware-vix-disklib-5.5.0-1284542.x86_64.tar.gz` at the time of this writing) from the VMware website.
 +
@@ -50,7 +50,7 @@ Use the following command to verify the VDDK files are listed and accessible to 
 
 . Restart the {product-title} appliance.
 
-The VDDK is now installed on the {product-title} appliance. This enables use of the SmartState Analysis Server Role on the appliance.
+The VDDK is now installed on the {product-title_short} appliance. This enables use of the SmartState Analysis Server Role on the appliance.
 
 
 

--- a/doc-Installing_on_VMware_vSphere/topics/installation.adoc
+++ b/doc-Installing_on_VMware_vSphere/topics/installation.adoc
@@ -1,12 +1,13 @@
 [[installing-cloudforms]]
 == Installing {product-title}
 
-{product-title} is able to be installed and ready to configure in a few quick steps. After downloading {product-title} as a virtual machine image template from the Red Hat Customer Portal, the installation process takes you through the steps of uploading the appliance to a supported virtualization or cloud provider.
+Installing {product-title} consists of the following steps:
 
-[IMPORTANT]
-====
-After installing the {product-title} appliance, you must configure the database for {product-title}. See xref:configuring_a_database[].
-====
+. Downloading the appliance for your environment as a virtual machine image template.
+. Setting up a virtual machine based on the appliance.
+. Configuring the {product-title_short} appliance.
+
+After you have completed all the procedures in this guide, you will have a working environment on which additional customizations and configurations can be performed.
 
 ifdef::miq[]
 [[obtaining-the-appliance]]
@@ -25,8 +26,8 @@ ifdef::cfme[]
 . Go to link:https://access.redhat.com[access.redhat.com] and log in to the Red Hat Customer Portal using your customer account details.
 . Click *Downloads* in the menu bar.
 . Click *A-Z* to sort the product downloads alphabetically.
-. Click menu:Red Hat CloudForms[Download Latest] to access the product download page.
-. From the list of installers and images, select the *CFME VMware Virtual Appliance* download link.
+. Click *Red Hat CloudForms* to access the product download page.
+. From the list of installers and images, click the *Download Now* link for *CFME VMware Virtual Appliance*.
 endif::cfme[]
 
 [[uploading-the-appliance-on-vmware-vsphere]]


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1497892

Applied the following updates to each installation guide and to the generalized configuration content (with the exception of Installing Red Hat CloudForms on OpenShift Container Platform guide)-

- Removed the opening paragraph and 'Important' admonition box at the start of   Chapter 1. and re-wrote this introduction to provide users with a brief overview of what installing CloudForms entails.
- Marked up 'Red Hat CloudForms' and 'Download Now' link in the procedure on downloading the appliance.
- Removed the opening line and 'Note' admonition box at the start of Chapter 2. and re-wrote the introduction to provide users with a brief overview of what configuring CloudForms entails including the mandatory steps.
- Changed the 'Changing Configuration Settings' procedure into a procedure that outlines how to access the appliance console.
- Removed steps to configure individual options - Advanced Configuration Settings
- Changed the title 'Configuring a Database for Red Hat CloudForms' to 'Configuring a Database' including other updates.

@cbudz Hi Chris,
Would you mind reviewing and merging the updates to the installation content? Let me know what you think.
Thanks!
Suyog