### PR TITLE
Bz#1519310 Removed master SAML URL

### DIFF
--- a/doc-General_Configuration/topics/Configuration.adoc
+++ b/doc-General_Configuration/topics/Configuration.adoc
@@ -1179,7 +1179,6 @@ To add a client in the Red Hat SSO {product-title_short} realm:
 | Setting                                     | Value
 | Name ID Format                              | username
 | Valid Redirect URIs                         | https://<miq-appliance>/saml2/postResponse
-| Master SAML Processing URL                  | https://<miq-appliance>/saml2
 | Assertion Consumer Service POST Binding URL | https://<miq-appliance>/saml2/postResponse
 | Logout Service Redirect Binding URL         | https://<miq-appliance>/saml2/logout
 |=========================================================================================
@@ -2056,7 +2055,7 @@ To create a user:
 . From the settings menu, select *Configuration*.
 . Click on the *Access Control* accordion, then click *Users*.
 . Click image:1847.png[] (*Configuration*), and image:plus_green.png[] (*Add a new User*) to create a user.
-. Enter a *Full Name*, *Username*, *Password* with confirmation, and *Email Address* for the user. 
+. Enter a *Full Name*, *Username*, *Password* with confirmation, and *Email Address* for the user.
 +
 image:available_groups.png[]
 +
@@ -2119,13 +2118,13 @@ After creating a group, assign one or more users to the group by editing a user.
 [[roles]]
 ==== Roles
 
-When you create a group, you must specify a role to give the group rights to resources in the console. The group's role determines the scope of access for the users that are members of the group. 
+When you create a group, you must specify a role to give the group rights to resources in the console. The group's role determines the scope of access for the users that are members of the group.
 
 image:CloudForms_General_Config_Roles_460469_1017_JCS.png[]
 
 A group can only be assigned one role when the local database is used for authentication, as shown in the above image.
 
-{product-title} provides a default group of roles, but you can also create your own, or copy and edit the default groups. 
+{product-title} provides a default group of roles, but you can also create your own, or copy and edit the default groups.
 
 [NOTE]
 ====
@@ -2138,7 +2137,7 @@ To view details of a role and its level of access:
 . Click on the *Access Control* accordion, then click *Roles*.
 . Click on a role from the list to display role information and the product features the role can access (marked by a checkmark). You can expand the categories under *Product Features* to see further detail.
 
-The table below shows a summary of the functions available to each role. 
+The table below shows a summary of the functions available to each role.
 
 [[account-roles-and-descriptions]]
 ===== Account Roles and Descriptions
@@ -3121,5 +3120,3 @@ The next options depend on the periodic database maintenance frequency you choos
 To reset your database maintenance settings, enter *Configure Database Maintenance* again from the appliance console menu, and confirm that you want to unconfigure the settings in the configuration dialog. This deletes the current settings.
 
 To configure a new database maintenance schedule, enter the *Configure Database Maintenance* menu item once again and configure the values using the dialog.
-
-


### PR DESCRIPTION
Hi Chris,

I've removed the line instructing users to configure the "Master SAML Processing URL" from the procedure under the heading "BZ#1519310-masterSAMLURL", which looks like all that is needed for this particular bug - https://bugzilla.redhat.com/show_bug.cgi?id=1519310
(The linked support case might require more docs changes in new BZs however, it's still ongoing).

Would you mind reviewing please? Let me know if you think anything else is needed to be clear.
I've also made this change in the WIP Authentication Guide branch in Gitlab so that it doesn't go missing (thanks for all your review work on that guide btw!)

Cheers,
Dayle