### PR TITLE
s/postgresql94/postgresql95/

### DIFF
--- a/doc-Appliance_Hardening_Guide/topics/DB_Password.adoc
+++ b/doc-Appliance_Hardening_Guide/topics/DB_Password.adoc
@@ -4,7 +4,7 @@
 Strengthening the host-based authentication (HBA) settings on a database appliance helps with preventing unauthorized access from external hosts.
 The HBA settings restrict access to an IP address range so that only hosts within that range have access.
 
-Restricting access to the database requires modifications to the `/var/opt/rh/rh-postgresql94/lib/pgsql/data/pg_hba.conf` file.
+Restricting access to the database requires modifications to the `/var/opt/rh/rh-postgresql95/lib/pgsql/data/pg_hba.conf` file.
 This file contains a text-based table with some initial settings:
 
 ------

--- a/doc-Appliance_Hardening_Guide/topics/DB_SSL.adoc
+++ b/doc-Appliance_Hardening_Guide/topics/DB_SSL.adoc
@@ -26,12 +26,12 @@ It is also recommended to stop all {product-title} services before configuring t
 To configure SSL on the database appliance:
 
 . Log in as `root` to the appliance where the database resides.
-. Stop the `evmserverd` and `rh-postgresql94-postgresql` services:
+. Stop the `evmserverd` and `rh-postgresql95-postgresql` services:
 +
 [subs="verbatim,attributes"]
 ----
 [root@{product-title_short_l}2 ~]# systemctl stop evmserverd
-[root@{product-title_short_l}2 ~]# systemctl stop rh-postgresql94-postgresql
+[root@{product-title_short_l}2 ~]# systemctl stop rh-postgresql95-postgresql
 ----
 
 . Install the server key file in the correct location and set the ownership and permissions for it:
@@ -63,7 +63,7 @@ To configure SSL on the database appliance:
 ----
 [root@{product-title_short_l}2 ~]# restorecon -R -v /var/www/miq/vmdb/certs
 ----
-. Open the `/var/opt/rh/rh-postgresql94/lib/pgsql/data/postgresql.conf` file and uncomment and edit the `ssl` option:
+. Open the `/var/opt/rh/rh-postgresql95/lib/pgsql/data/postgresql.conf` file and uncomment and edit the `ssl` option:
 +
 ----
 
@@ -80,7 +80,7 @@ ssl_key_file  = '/var/www/miq/vmdb/certs/postgres.key'  # (change requires resta
 ssl_ca_file   = '/var/www/miq/vmdb/certs/root.crt'      # (change requires restart)
 ----
 
-. Open the `/var/opt/rh/rh-postgresql94/lib/pgsql/data/pg_hba.conf` file and locate the two lines that contain the following:
+. Open the `/var/opt/rh/rh-postgresql95/lib/pgsql/data/pg_hba.conf` file and locate the two lines that contain the following:
 +
 [source]
 ----
@@ -100,11 +100,11 @@ hostssl   all      all   all           md5
 +
 This changes the incoming communication protocol to use SSL and refuse any unencrypted PostgreSQL connections.
 
-. Start the `rh-postgresql94-postgresql` and `evmserverd` services so that the changes take effect:
+. Start the `rh-postgresql95-postgresql` and `evmserverd` services so that the changes take effect:
 +
 [subs="verbatim,attributes"]
 ----
-[root@{product-title_short_l}1 ~]# systemctl start rh-postgresql94-postgresql
+[root@{product-title_short_l}1 ~]# systemctl start rh-postgresql95-postgresql
 [root@{product-title_short_l}1 ~]# systemctl start evmserverd
 ----
 
@@ -152,7 +152,7 @@ This enhances the security of all database transactions in your {product-title} 
 
 ==== Hardening TLS Protocol Version
  
-After configuring the database to use SSL, protocol TLS version 1.2 is used as default. The older versions of this protocol (TLS 1.0 and 1.1) are still available for clients to choose. You can disable older versions by inserting the following lines into `/var/opt/rh/rh-postgresql94/lib/pgsql/data/postgresql.conf`:
+After configuring the database to use SSL, protocol TLS version 1.2 is used as default. The older versions of this protocol (TLS 1.0 and 1.1) are still available for clients to choose. You can disable older versions by inserting the following lines into `/var/opt/rh/rh-postgresql95/lib/pgsql/data/postgresql.conf`:
  
 ----
 ssl_ciphers = 'TLSv1.2:!aNULL'

--- a/doc-General_Configuration/topics/Configuration.adoc
+++ b/doc-General_Configuration/topics/Configuration.adoc
@@ -1624,9 +1624,9 @@ log/\*.txt
 
 config/*
 
-/var/opt/rh/rh-postgresql94/lib/pgsql/data/\*.conf
+/var/opt/rh/rh-postgresql95/lib/pgsql/data/\*.conf
 
-/var/opt/rh/rh-postgresql94/lib/pgsql/data/pg_log/*
+/var/opt/rh/rh-postgresql95/lib/pgsql/data/pg_log/*
 
 /var/log/syslog*
 


### PR DESCRIPTION
We've been on PG 9.5 for about a year.

There are also very similar instances of this issue in `doc-Appliance_Hardening_Guide/miq/build/en-US/master.xml`. Should I change those also or are those files generated by some build process? 