### PR TITLE
fixed typo in method

### DIFF
--- a/doc-Methods_Available_for_Automation/topics/Service2.adoc
+++ b/doc-Methods_Available_for_Automation/topics/Service2.adoc
@@ -27,12 +27,12 @@
 
 | 
 						
-							customer_get
+							custom_get
 						
 					
 | 
 						
-							Gets Value for specified custom key
+							Gets value for specified custom key
 						
 					
 

--- a/doc-Methods_Available_for_Automation/topics/Service2.adoc
+++ b/doc-Methods_Available_for_Automation/topics/Service2.adoc
@@ -27,7 +27,7 @@
 
 | 
 						
-							custom_get
+							custom_get(key)
 						
 					
 | 


### PR DESCRIPTION
Hi Chris,
I've fixed the typo in the method -- it only exists in this one place in the guide.
Please let me know if you spot any additional edits for this issue -
 https://bugzilla.redhat.com/show_bug.cgi?id=1531962
Thanks for your review!  
Dayle