### PR TITLE
Removed Middleware providers from master.adoc

### DIFF
--- a/doc-Managing_Providers/cfme/master.adoc
+++ b/doc-Managing_Providers/cfme/master.adoc
@@ -51,9 +51,6 @@ include::topics/Cloud_Providers.adoc[]
 include::topics/Networking_Providers.adoc[]
 
 :leveloffset: 1
-include::topics/Middleware_Providers.adoc[]
-
-:leveloffset: 1
 include::topics/Containers_Providers.adoc[]
 
 :leveloffset: 1


### PR DESCRIPTION
Middleware_Providers.adoc file was removed but still listed in master.adoc - now fixed.