### PR TITLE
Removed old authentication content from GC

### DIFF
--- a/doc-General_Configuration/topics/Configuration.adoc
+++ b/doc-General_Configuration/topics/Configuration.adoc
@@ -731,11 +731,12 @@ image:2066.png[]
 
 Use the *Authentication* tab to specify how you want users authenticated on the console. You can use the VMDB or integrate with LDAP, LDAPS, Amazon, or an external IPA server.
 
+ifdef::cfme[]
 [NOTE]
 ====
 See https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6-beta/html-single/managing_authentication_for_cloudforms/[_Managing Authentication_] for information on configuring different types of authentication for {product-title_short}.
 ====
-
+endif::cfme[]
 
 
 [[changing-authentication-settings]]
@@ -2090,8 +2091,9 @@ image:available_groups.png[]
 ====
 * If you are using LDAP, but did not enable *Get User Groups from LDAP* in your server's *Authentication* tab, you will need to define a user. The UserID must match exactly the user's name as defined in your directory service. Use all lowercase characters to ensure the user can be found in the VMDB.
 * When the user logs in, they use their LDAP password.
+ifdef::cfme[]
 * For more information on configuring LDAP authentication in {product-title_short}, see https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6-beta/html-single/managing_authentication_for_cloudforms/#ldap_config[Configuring LDAP or LDAPS Authentication] in _Managing Authentication_.
-====
+endif::cfme[]
 ====
 +
 . Select one or more groups from *Available Groups*.
@@ -2117,10 +2119,12 @@ For a list of what each pre-defined account role can do, see xref:roles[].
 
 A user can exist in multiple groups. However, a group can only be assigned one account role.
 
+ifdef::cfme[]
 [NOTE]
 ====
 See https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6-beta/html-single/managing_authentication_for_cloudforms/#assigning_account_roles_using_ldap_groups[Assigning CloudForms Account Roles Using LDAP Groups] in _Managing Authentication_.
 ====
+endif::cfme[]
 
 [[creating-a-user-group]]
 ==== Creating a Group
@@ -2160,7 +2164,10 @@ A group can only be assigned one role when the local database is used for authen
 
 [NOTE]
 ====
-If you have enabled *Get Role from LDAP* under *LDAP Settings*, then the role is determined by the LDAP user's group membership in the directory service. See https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6-beta/html-single/managing_authentication_for_cloudforms/#ldap_config[Configuring LDAP or LDAPS Authentication] in _Managing Authentication_.
+If you have enabled *Get Role from LDAP* under *LDAP Settings*, then the role is determined by the LDAP user's group membership in the directory service. 
+ifdef::cfme[]
+See https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6-beta/html-single/managing_authentication_for_cloudforms/#ldap_config[Configuring LDAP or LDAPS Authentication] in _Managing Authentication_.
+endif::cfme[]
 ====
 
 To view details of a role and its level of access:

--- a/doc-General_Configuration/topics/Configuration.adoc
+++ b/doc-General_Configuration/topics/Configuration.adoc
@@ -731,6 +731,13 @@ image:2066.png[]
 
 Use the *Authentication* tab to specify how you want users authenticated on the console. You can use the VMDB or integrate with LDAP, LDAPS, Amazon, or an external IPA server.
 
+[NOTE]
+====
+See https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6-beta/html-single/managing_authentication_for_cloudforms/[_Managing Authentication_] for information on configuring different types of authentication for {product-title_short}.
+====
+
+
+
 [[changing-authentication-settings]]
 ====== Changing Authentication Settings
 
@@ -742,12 +749,12 @@ To change authentication settings:
 . Click the server.
 . Click the *Authentication* tab.
 . Use *Session Timeout* to set the period of inactivity before a user is logged out of the console.
-. Set the authentication method in *Mode*. Choose from *Database* (using the VMDB), *LDAP* (Lightweight Directory Authentication Protocol), *LDAPS* (Secure Lightweight Directory Authentication Protocol), *Amazon*, or *External (httpd)*. The default is *Database*.
-* If you choose *Database*, see xref:creating_a_user[] for steps to create users.
-* If you choose *LDAP* or *LDAPS*, see xref:ldap_settings[] for configuration steps.
-* If you choose *Amazon*, see xref:amazon_settings[] for configuration steps.
-* If you choose *External (httpd)*, see xref:external_ipa_auth[] for configuration steps.
+. Set the authentication method in *Mode*.
 . Click *Save*.
+
+////
+
+Note: commenting all of this content out as it's now in the Managing Authentication guide. Leaving in this guide temporarily in case it is needed for any reason. All xrefs to this section have been changed to URLs to the new guide. We can probably delete this content entirely after 4.6 is released.
 
 [[ldap_settings]]
 ====== Configuring LDAP Authentication
@@ -1322,6 +1329,8 @@ Alternatively, log into the appliance as root using SSH, and run the following c
 ------
 # appliance_console_cli --extauth-opts local_login_disabled=false
 ------
+
+////
 
 [[workers-1]]
 ===== Workers
@@ -2081,6 +2090,8 @@ image:available_groups.png[]
 ====
 * If you are using LDAP, but did not enable *Get User Groups from LDAP* in your server's *Authentication* tab, you will need to define a user. The UserID must match exactly the user's name as defined in your directory service. Use all lowercase characters to ensure the user can be found in the VMDB.
 * When the user logs in, they use their LDAP password.
+* For more information on configuring LDAP authentication in {product-title_short}, see https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6-beta/html-single/managing_authentication_for_cloudforms/#ldap_config[Configuring LDAP or LDAPS Authentication] in _Managing Authentication_.
+====
 ====
 +
 . Select one or more groups from *Available Groups*.
@@ -2108,7 +2119,7 @@ A user can exist in multiple groups. However, a group can only be assigned one a
 
 [NOTE]
 ====
-To assign account roles using LDAP groups, see xref:assigning_account_roles_using_ldap_groups[].
+See https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6-beta/html-single/managing_authentication_for_cloudforms/#assigning_account_roles_using_ldap_groups[Assigning CloudForms Account Roles Using LDAP Groups] in _Managing Authentication_.
 ====
 
 [[creating-a-user-group]]
@@ -2149,7 +2160,7 @@ A group can only be assigned one role when the local database is used for authen
 
 [NOTE]
 ====
-If you have enabled *Get Role from LDAP* under *LDAP Settings*, then the role is determined by the LDAP user's group membership in the directory service. See xref:ldap_settings[].
+If you have enabled *Get Role from LDAP* under *LDAP Settings*, then the role is determined by the LDAP user's group membership in the directory service. See https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6-beta/html-single/managing_authentication_for_cloudforms/#ldap_config[Configuring LDAP or LDAPS Authentication] in _Managing Authentication_.
 ====
 
 To view details of a role and its level of access:


### PR DESCRIPTION
removed all authentication instructions that are in the new Managing Auth for CF guide. Commented out the old content for now, in case of any issues, but we can probably delete it entirely at release time. Also, any xrefs to various LDAP sections, etc, are now URLs to the new guide