### PR TITLE
add overview on playbooks service linking roles docs

### DIFF
--- a/doc-Managing_Providers/topics/Adding_Ansible_Galaxy_Roles.adoc
+++ b/doc-Managing_Providers/topics/Adding_Ansible_Galaxy_Roles.adoc
@@ -1,0 +1,18 @@
+[[installing-ansible-roles]]
+
+=== Installing Roles on an Embedded Ansible Appliance 
+
+Roles are ways of automatically loading certain variable files, tasks, and handlers based on a known file structure. Grouping content by roles also allows easy sharing of roles with other users. 
+Install roles on a {product-title} appliance with the Embedded Ansible server role activated to optimize playbooks. 
+
+
+When using this role in a playbook on a {product-title_short} appliance, add an empty `roles` directory at the root of the playbook. In the `roles` directory, include a `requirements.yml` file with the following contents:
+ 
+-----
+---
+- src: <ansible-galaxy-role>
+-----
+
+{product-title_short} will automatically install the role once it sees the `requirements.yml` file in the playbook.
+ 
+

--- a/doc-Managing_Providers/topics/Ansible_Service_Linking.adoc
+++ b/doc-Managing_Providers/topics/Ansible_Service_Linking.adoc
@@ -3,22 +3,22 @@
 
 {product-title} provides a module allowing inventoried resources such as virtual machines created using Ansible playbooks to link back to the services used to generate them. During service ordering of a playbook the `add_provider_vms` module will allow the playbook to connect back to the worker appliance and identify the provider resources it was responsible for generating. Once linked, the newly generated resources are available to {product-title_short}'s life cycle management features.
 
-Linking VMs back to the service that created it requires implementing the following tasks in the playbook used for provisioning. 
+Linking VMs back to the service that created it requires implementing the following tasks in the playbook used for provisioning: 
 
 . Create a resource and register it.
 . Link the service using the `add_provider_vms` method to the newly created resource. 
 
 
 
-==== Example
+==== Example: Linking a virtual machine to a service
 
 In the following playbook task examples, a virtual machine is deployed to Amazon EC2 and linked back to the service. Examples are provided for linking the resource to its service by both an href slug and as an object. 
  
 [NOTE]
 ====
 * This example utilizes the `syncrou.manageiq-vmdb`role. This role allows {product-title_short} users to modify and/or change VMDB objects using an Ansible playbook. For information on implementing and utilizing roles when writing Ansible playbooks for {product-title_short}, see xref:installing-ansible-roles[]. 
-* For more information on Ansible Galaxy and roles, see the Ansible Galaxy documentation. 
-* Please note the provider ID in order to successfully link to the service. 
+* For more information on Ansible Galaxy and roles, see the http://docs.ansible.com/ansible/latest/galaxy.html[Ansible Galaxy documentation]. 
+* Note the provider ID in order to successfully link to the service. 
 ====
 
 . Create and register the resource.
@@ -39,7 +39,7 @@ In the following playbook task examples, a virtual machine is deployed to Amazon
   register: ec2
 -----
 +
-. Call the `add_provider_vms` method as an action to link to the service via an href slug.
+. Call the `add_provider_vms` method as an action to link to the service via an _href slug_ or an object.
 +
 -----
 - name: Service Linking via an href slug
@@ -51,11 +51,7 @@ In the following playbook task examples, a virtual machine is deployed to Amazon
         - "{{ ec2.instances[0].id }}"
       provider:
         id: 24
------
-+
-. Or, link to the service as an object.
-+
------
+
 - name: Service Linking via an object
   manageiq_vmdb:
     vmdb: "{{ vmdb_object }}"

--- a/doc-Managing_Providers/topics/Ansible_Service_Linking.adoc
+++ b/doc-Managing_Providers/topics/Ansible_Service_Linking.adoc
@@ -16,15 +16,9 @@ In the following playbook task examples, a virtual machine is deployed to Amazon
  
 [NOTE]
 ====
-<<<<<<< HEAD
 * This example utilizes the `syncrou.manageiq-vmdb`role. This role allows {product-title_short} users to modify and/or change VMDB objects using an Ansible playbook. For information on implementing and utilizing roles when writing Ansible playbooks for {product-title_short}, see xref:installing-ansible-roles[]. 
 * For more information on Ansible Galaxy and roles, see the http://docs.ansible.com/ansible/latest/galaxy.html[Ansible Galaxy documentation]. 
 * Note the provider ID in order to successfully link to the service. 
-=======
-* This example utilizes the `syncrou.manageiq-vmdb` role. This role allows {product-title_short} users to modify and/or change VMDB objects using an Ansible playbook. For information on implementing and utilizing roles when writing Ansible playbooks for {product-title_short}, see xref:installing-ansible-roles[]. 
-* For more information on Ansible Galaxy and roles, see the Ansible Galaxy documentation. 
-* Please note the provider ID in order to successfully link to the service. 
->>>>>>> ace80fff8249817860ab1d796c526f47c50e75af
 ====
 
 . Create and register the resource.

--- a/doc-Managing_Providers/topics/Ansible_Service_Linking.adoc
+++ b/doc-Managing_Providers/topics/Ansible_Service_Linking.adoc
@@ -12,7 +12,7 @@ Linking VMs back to the service that created it requires implementing the follow
 
 ==== Example: Linking a virtual machine to a service
 
-In the following playbook task examples, a virtual machine is deployed to Amazon EC2 and linked back to the service. Examples are provided for linking the resource to its service by both an href slug and as an object. 
+In the following playbook task examples, a virtual machine is deployed to Amazon EC2 and linked back to the service. Examples are provided for linking the resource to its service by both an _href slug_ and as an object. 
  
 [NOTE]
 ====

--- a/doc-Managing_Providers/topics/Ansible_Service_Linking.adoc
+++ b/doc-Managing_Providers/topics/Ansible_Service_Linking.adoc
@@ -1,0 +1,69 @@
+[[ansible-service-linking]]
+=== Ansible Service Linking 
+
+{product-title} provides a module allowing inventoried resources such as virtual machines created using Ansible playbooks to link back to the services used to generate them. During service ordering of a playbook the `add_provider_vms` module will allow the playbook to connect back to the worker appliance and identify the provider resources it was responsible for generating. Once linked, the newly generated resources are available to {product-title_short}'s life cycle management features.
+
+Linking VMs back to the service that created it requires implementing the following tasks in the playbook used for provisioning. 
+
+. Create a resource and register it.
+. Link the service using the `add_provider_vms` method to the newly created resource. 
+
+
+
+==== Example
+
+In the following playbook task examples, a virtual machine is deployed to Amazon EC2 and linked back to the service. Examples are provided for linking the resource to its service by both an href slug and as an object. 
+ 
+[NOTE]
+====
+* This example utilizes the `syncrou.manageiq-vmdb`role. This role allows {product-title_short} users to modify and/or change VMDB objects using an Ansible playbook. For information on implementing and utilizing roles when writing Ansible playbooks for {product-title_short}, see xref:installing-ansible-roles[]. 
+* For more information on Ansible Galaxy and roles, see the Ansible Galaxy documentation. 
+* Please note the provider ID in order to successfully link to the service. 
+====
+
+. Create and register the resource.
++
+-----
+- name: Create Ec2 Instance
+  ec2:
+    key_name: "{{ key }}"
+    instance_tags: {Name: "{{ name }}"}
+    group_id: "{{ security_group }}"
+    instance_type: "{{ instance_type }}"
+    region: "{{ region }}"
+    image: "{{ image }}"
+    wait: yes
+    count: 1
+    vpc_subnet_id: "{{ subnet }}"
+    assign_public_ip: yes
+  register: ec2
+-----
++
+. Call the `add_provider_vms` method as an action to link to the service via an href slug.
++
+-----
+- name: Service Linking via an href slug
+  manageiq_vmdb:
+    href: "href_slug::services/80"
+    action: add_provider_vms
+    data:
+      uid_ems:
+        - "{{ ec2.instances[0].id }}"
+      provider:
+        id: 24
+-----
++
+. Or, link to the service as an object.
++
+-----
+- name: Service Linking via an object
+  manageiq_vmdb:
+    vmdb: "{{ vmdb_object }}"
+    action: add_provider_vms
+    data:
+      uid_ems:
+        - "{{ ec2.instances[0].id }}"
+      provider:
+        id: 24
+
+-----

--- a/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
+++ b/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
@@ -108,7 +108,8 @@ If both {product-title_short} and a VMware provider are located in the same IPv6
 :leveloffset: 3
 include::Ansible_Credentials.adoc[]
 
-include::manageiq-automate-role.adoc[]
+:leveloffset: 3
+include::Optimizing_Playbooks.adoc[]
 
 :leveloffset: 1
 [[ansible-tower]]

--- a/doc-Managing_Providers/topics/Optimizing_Playbooks.adoc
+++ b/doc-Managing_Providers/topics/Optimizing_Playbooks.adoc
@@ -1,0 +1,13 @@
+[[optimizing-playbooksOPtimi]]
+= Optimizing Ansible Playbooks for {product-title}
+
+Ansible is a simple model-driven configuration management, multi-node deployment, and remote-task execution system. When designing playbooks for use with {product-title_short} it is helpful to utilize solutions within the playbook itself to ensure optimal implementation of playbook-backed services or automated processes.  
+
+This section is intended to compliment the existing documentation on Ansible playbooks and guide administrators through optimizing playbooks for use with {product-title_short}.
+
+include::Adding_Ansible_Galaxy_Roles.adoc[]
+
+include::Ansible_Service_Linking.adoc[]
+
+include::manageiq-automate-role.adoc[]
+

--- a/doc-Managing_Providers/topics/Optimizing_Playbooks.adoc
+++ b/doc-Managing_Providers/topics/Optimizing_Playbooks.adoc
@@ -3,7 +3,7 @@
 
 Ansible is a simple model-driven configuration management, multi-node deployment, and remote-task execution system. When designing playbooks for use with {product-title_short} it is helpful to utilize solutions within the playbook itself to ensure optimal implementation of playbook-backed services or automated processes.  
 
-This section is intended to compliment the existing documentation on Ansible playbooks and guide administrators through optimizing playbooks for use with {product-title_short}.
+This section is intended to complement the existing documentation on Ansible playbooks and guide administrators through optimizing playbooks for use with {product-title_short}.
 
 include::Adding_Ansible_Galaxy_Roles.adoc[]
 

--- a/doc-Managing_Providers/topics/Optimizing_Playbooks.adoc
+++ b/doc-Managing_Providers/topics/Optimizing_Playbooks.adoc
@@ -1,4 +1,4 @@
-[[optimizing-playbooksOPtimi]]
+[[optimizing-playbooks]]
 = Optimizing Ansible Playbooks for {product-title}
 
 Ansible is a simple model-driven configuration management, multi-node deployment, and remote-task execution system. When designing playbooks for use with {product-title_short} it is helpful to utilize solutions within the playbook itself to ensure optimal implementation of playbook-backed services or automated processes.  


### PR DESCRIPTION
Hi Dayle, 

Would you mind having a look at the files I've included here that cover the following:

- Service Linking: this is the primary request for the BZ
- Installing Roles: an inclusion that comes with the territory of working with roles.
- Optimizing Playbooks: this is based on the suggestion Andrew made in the BZ, about creating a new section on writing playbooks for use with CF.

Preview is included in the BZ

Thanks,
Chris