### PR TITLE
fixed region/database step, added port step

### DIFF
--- a/common/configuration.adoc
+++ b/common/configuration.adoc
@@ -111,8 +111,9 @@ endif::ssh[]
 All {product-title_short} appliances in a multi-region deployment must use the same key.
 ====
 +
-. Choose *2) Create Region in External Database* for the database location.
+. Choose *3) Join Region in External Database* for the database location.
 . Enter the database hostname or IP address when prompted.
+. Enter the port number or leave blank for the default (`5432`).
 . Enter the database name or leave blank for the default (`vmdb_production`).
 . Enter the database username or leave blank for the default (`root`).
 . Enter the chosen database user's password.


### PR DESCRIPTION
Hey Chris,
I've fixed the incorrect step that Krain has pointed out in https://bugzilla.redhat.com/show_bug.cgi?id=1520900, but also found when testing in 4.6 that now entering a port number is a step in this procedure, so I've added that too.

(Note, my testing didn't come across the step "You are prompted to create or fetch a security key.", but I'm reluctant to remove it as I was only testing this one procedure in isolation without multiple appliances, and Krain didn't see an issue with that -- so I'm hoping it's OK to leave that in)

Please let me know what you think.
Cheers,
Dayle
