### PR TITLE
Correct steps to configure replication global copy

### DIFF
--- a/doc-General_Configuration/topics/Configuration.adoc
+++ b/doc-General_Configuration/topics/Configuration.adoc
@@ -2724,8 +2724,10 @@ Configure a {product-title} instance to act as the global copy to which data is 
 
 image:add-subscription-global.png[Add Subscription]
 
-. Log in to the appliance as the *root* user.
-. Enter `appliance_console`, and press *Enter*.
+. Navigate to the settings menu.
+. Click *Configuration*.
+. Click the *Settings* accordion.
+. Click the region where the instance is located.
 . Click *Replication*.
 . Select *Global* from the *Type* list.
 . Click *Add Subscription*.


### PR DESCRIPTION
…html/general_configuration/configuration#database-regions-and-replication

Section 4.4.3.2. Configuring the Global Copy
Initial instructions are for cmdline - however the image and following instructions assume access to GUI. So changesd the instructions according to the 4.4.3.1. Configuring a Remote Copy