### PR TITLE
update custom button doc

### DIFF
--- a/common/automate-custom-button.adoc
+++ b/common/automate-custom-button.adoc
@@ -30,7 +30,7 @@ If image:../images/1862.png[image] (*Add a new Button*) is not available, that m
 .. Select a *Submit* parameter to choose how to submit objects to automate. Selecting _Submit All_ will pass all objects at once when the button is executed, while choosing _One by one_ will run execute the button action each time per object. 
 +
 . Under the *Advanced* tab:
-.. Set button *Enablement*. Click *Define Expression* to access the expression editor tool. Provide *Disabled Button Text* to display when the custom button is disabled. 
+.. Set button *Enablement*. Click *Define Expression* to access the expression editor tool. Enter *Disabled Button Text* to display when the custom button is disabled. 
 .. Use *Visibility* to determine button appearance based on a custom expression. Click *Define Expression* to access the expression editor tool. 
 +
 [NOTE]
@@ -40,9 +40,9 @@ For more about setting visibility and enablement for a custom button, see <<filt
 +
 .. In *Object Details*, select *Request* from the `/System/Process/` dropdown. By default, the message is `create`. Do not change it.
 
-.. Type in a *Request* name for the `/System/Process/Request` instance.
+.. Enter a *Request* name for the `/System/Process/Request` instance.
 
-.. Type in the `Attribute/Value Pairs` fields if applicable.
+.. Enter the *Attribute/Value Pairs* fields if applicable.
 
 .. Set *Role Access*. Selecting _<By Role>_ will display available roles. Check applicable roles. 
 

--- a/common/automate-custom-button.adoc
+++ b/common/automate-custom-button.adoc
@@ -23,7 +23,7 @@ If image:../images/1862.png[image] (*Add a new Button*) is not available, that m
 
 . Under the *Options* tab:
 .. Select the *Button* type from the list. 
-.. Type in button *Text* and *Hover Text*, and select the *Icon* and *Icon Color* to use.
+.. Enter button *Text* and *Hover Text*, and select the *Icon* and *Icon Color* to use.
 .. Select a *Dialog* if applicable.
 .. Check *Open URL* to open a browser window for the custom URL returned when the button is executed.  
 .. Choose a *Display For* option for the button. 

--- a/common/automate-custom-button.adoc
+++ b/common/automate-custom-button.adoc
@@ -20,16 +20,30 @@ image:../images/1862.png[image] (*Add a new Button*).
 ====
 If image:../images/1862.png[image] (*Add a new Button*) is not available, that means you have not created a button group for that object. To continue, create a button group first. See <<create-custom-button-group>>
 ====
-. In *Action*, type in a *Button Text* and *Button Hover Text*, and select the *Button Image* you want to use.
 
-. Select a *Dialog* if applicable.
+. Under the *Options* tab:
+.. Select the *Button* type from the list. 
+.. Type in button *Text* and *Hover Text*, and select the *Icon* and *Icon Color* to use.
+.. Select a *Dialog* if applicable.
+.. Check *Open URL* to open a browser window for the custom URL returned when the button is executed.  
+.. Choose a *Display For* option for the button. 
+.. Select a *Submit* parameter to choose how to submit objects to automate. Selecting _Submit All_ will pass all objects at once when the button is executed, while choosing _One by one_ will run execute the button action each time per object. 
++
+. Under the *Advanced* tab:
+.. Set button *Enablement*. Click *Define Expression* to access the expression editor tool. Provide *Disabled Button Text* to display when the custom button is disabled. 
+.. Use *Visibility* to determine button appearance based on a custom expression. Click *Define Expression* to access the expression editor tool. 
++
+[NOTE]
+====
+For more about setting visibility and enablement for a custom button, see <<filtering-actions-custom-buttons>>.
+====
++
+.. In *Object Details*, select *Request* from the `/System/Process/` dropdown. By default, the message is `create`. Do not change it.
 
-. In *Object Details*, select *Request* from the `/System/Process/` dropdown. By default, the message is `create`. Do not change it.
+.. Type in a *Request* name for the `/System/Process/Request` instance.
 
-. Type in a *Request* name for the `/System/Process/Request` instance.
+.. Type in the `Attribute/Value Pairs` fields if applicable.
 
-. Type in the `Attribute/Value Pairs` fields if applicable.
-
-. Under *Visibility*, select which *Account Roles* you want to have access to this button.
+.. Set *Role Access*. Selecting _<By Role>_ will display available roles. Check applicable roles. 
 
 . Click *Add* when you have confirmed that the button accomplishes the task you want.

--- a/doc-Scripting_Actions/topics/Filtering-Actions-for-Custom-Buttons.adoc
+++ b/doc-Scripting_Actions/topics/Filtering-Actions-for-Custom-Buttons.adoc
@@ -1,6 +1,6 @@
 [[filtering-actions-custom-buttons]]
 
-=== Applying Visibility and Enablement Filtering Actions to Custom Buttons
+=== Setting Enablement and Visibility for Custom Buttons
 
 {product-title} adds methods for evaluating an expression to determine whether a custom button is visible and enabled. Each method has a target object, for example, a virtual machine or host, and expressions can set a custom button to visible, hidden, or disabled.
 


### PR DESCRIPTION
Hey Suyog,

I've made some updates here to the Custom Button creation doc. The original BZ calls out inaccuracy regarding Step 11. Visibility, but I noticed when working through the UI that the instructions, generally, were outdated. So I've updated them. 

For instructions under the Advanced tab, I added a note directing users to the section on Enablement and Visibility. Let me know what you think about that.

I also updated the title for the Enablment and Visibility doc. When I intiailly wrote it, Dayle mentioned in her QA that it was rather cumbersome. I wholeheartedly agreed, and took the opportunity to update it while I was working in this doc set. 

Preview is available in the BZ.

-Chris