### PR TITLE
Update custom flavor root disk size

### DIFF
--- a/doc-Installing_on_Red_Hat_Enterprise_Linux_OpenStack_Platform/topics/installation.adoc
+++ b/doc-Installing_on_Red_Hat_Enterprise_Linux_OpenStack_Platform/topics/installation.adoc
@@ -92,7 +92,7 @@ The following procedure demonstrates creating a flavor with the minimum requirem
 +
 * *VCPUs*: 4
 * *RAM MB*: 12288
-* *Root Disk GB*: 45
+* *Root Disk GB*: 70
 * *Ephemeral Disk GB*: 0
 * *Swap Disk MB*: 0
 +


### PR DESCRIPTION
The MIQ openstack virtual disk size is actually 66GB, so creating a flavor with a 45GB root disk as specified in the docs will throw an error when trying to deploy the image using the custom flavor.

```
$ qemu-img info manageiq-openstack-gaprindashvili-2.qc2
image: manageiq-openstack-gaprindashvili-2.qc2
file format: qcow2
virtual size: 66G (70866960384 bytes)
disk size: 1.6G
cluster_size: 65536
Format specific information:
    compat: 0.10
    refcount bits: 16
```