### PR TITLE
removed non-supported OCP versions from docs

### DIFF
--- a/doc-Managing_Providers/topics/Containers_Providers.adoc
+++ b/doc-Managing_Providers/topics/Containers_Providers.adoc
@@ -50,25 +50,10 @@ When deploying OpenShift using `openshift-ansible-3.0.20` (or later versions), t
 See the link:https://docs.openshift.com/container-platform/latest/architecture/additional_concepts/authorization.html#roles[OpenShift Container Platform documentation] for a list of the default roles.
 ====
 
-To obtain the token to use for the provider definition, follow the instructions below for your OpenShift Container Platform version.
+Run the following to obtain the token needed to add an OpenShift Container Platform provider:
 
-
-[[obtaining-a-management-token-in-openshift-container-platform]]
-== Obtaining a Management Token in OpenShift Container Platform 3.3 and Later
-
-include::../common/provider-ocp-mgt-token.adoc[]
-
-
-[[obtaining-a-management-token-in-openshift-enterprise-3.2]]
-== Obtaining a Management Token in OpenShift Enterprise 3.2
-
-include::../common/provider-ose-mgt-token-3_2.adoc[]
-
-
-[[obtaining-a-management-token-in-openshift-enterprise-3.1]]
-== Obtaining a Management Token in OpenShift Enterprise 3.1
-
-include::../common/provider-ose-mgt-token-3_1.adoc[]
+  # oc sa get-token -n management-infra management-admin
+  eyJhbGciOiJSUzI1NiI...
 
 
 :leveloffset: 2


### PR DESCRIPTION
Removed extra section and unsupported versions of OCP as token obtaining is the same since OCP 3.3, and we support 3.5, 3.6, 3.7.