### PR TITLE
Add note regarding host input value configurations

### DIFF
--- a/doc-Scripting_Actions/topics/To_create_an_Ansible_Playbook_button.adoc
+++ b/doc-Scripting_Actions/topics/To_create_an_Ansible_Playbook_button.adoc
@@ -29,9 +29,11 @@ If image:../images/1862.png[image] (*Add a new Button*) is not available, that m
 +
 [NOTE]
 ====
-To allow service dialogs associated with the custom button to override user input set the custom button to "Specific Hosts" and leave the associated text field blank.
+{product-title_short} supports two configurations for host input:
 
-Otherwise, the admin selected value will be used regardless of the value specified on the dialog by the user.  To avoid confusion the admin should remove the "Hosts" field from the dialog the service is using.
+* To allow user-provided host details, set the custom button to *Specific Hosts* and leave the associated text field blank. 
+
+* Remove the *Hosts* field when creating the dialog the service uses. In this configuration, the admin specified value is used. 
 ====
 +
 . Type in a *Text* and *Hover Text*, and select the *Icon* you want to use.

--- a/doc-Scripting_Actions/topics/To_create_an_Ansible_Playbook_button.adoc
+++ b/doc-Scripting_Actions/topics/To_create_an_Ansible_Playbook_button.adoc
@@ -26,7 +26,14 @@ If image:../images/1862.png[image] (*Add a new Button*) is not available, that m
 . Select *Ansible Playbook* from the *Button Type* drop-down menu. 
 . From the *Playbook Catalog Item* choose a playbook-backed catalog item to run.
 . Choose a host from the *Inventory* against which to run the playbook. If *Specific Hosts* is selected, input the IP address or DNS names for each host in the text field, separating each with a comma. 
++
+[NOTE]
+====
+To allow service dialogs associated with the custom button to override user input set the custom button to "Specific Hosts" and leave the associated text field blank.
 
+Otherwise, the admin selected value will be used regardless of the value specified on the dialog by the user.  To avoid confusion the admin should remove the "Hosts" field from the dialog the service is using.
+====
++
 . Type in a *Text* and *Hover Text*, and select the *Icon* you want to use.
 . Select an *Icon Color* from the  color selection palette that pops up. 
 . Check *Open URL* to open a browser window for the custom URL returned when the playbook is run. 

--- a/doc-Scripting_Actions/topics/To_create_an_Ansible_Playbook_button.adoc
+++ b/doc-Scripting_Actions/topics/To_create_an_Ansible_Playbook_button.adoc
@@ -29,11 +29,11 @@ If image:../images/1862.png[image] (*Add a new Button*) is not available, that m
 +
 [NOTE]
 ====
-{product-title_short} supports two configurations for host input:
+{product-title_short} supports two configurations for host value input:
 
-* To allow user-provided host details, set the custom button to *Specific Hosts* and leave the associated text field blank. 
+* To allow user-provided host values, set the custom button to *Specific Hosts* and leave the associated text field blank. 
 
-* Remove the *Hosts* field when creating the dialog the service uses. In this configuration, the admin specified value is used. 
+* To use admin-specified host values, remove the *Hosts* field when creating the dialog the service uses. In this configuration, the field will not appear to users. See link:https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6/html/provisioning_virtual_machines_and_hosts/catalogs-services#service-dialogs[Service Dialogs] for information on generating a service dialog. 
 ====
 +
 . Type in a *Text* and *Hover Text*, and select the *Icon* you want to use.


### PR DESCRIPTION
Hi Dayle,

I've added a note here in the ansible playbook custom button procedure related to the supported configurations for host value input. You'll notice the step that immediately preceeds the note addresses adding values for "specific hosts", then the note supplements that information. Please let me know if the details included in the note are clear and provide a distinction in how that info is provided (admin vs user). 

Thanks!
Chris