### PR TITLE
Updated load balancer docs in DPG; HA guide 

### DIFF
--- a/doc-Deployment_Planning_Guide/topics/planning.adoc
+++ b/doc-Deployment_Planning_Guide/topics/planning.adoc
@@ -214,18 +214,21 @@ Providers can be added at any level of tenancy. Once added, a provider is visibl
 
 Deploying multiple user interface worker appliances and placing them behind a third-party load balancer allows for redundancy and improved performance. This requires extra configuration in both the load balancer and in the {product-title_short} user interface worker appliances.
 
-.Load balancer configuration
+==== Configuring the Load Balancer
 
 * Configure the load balancer to use sticky sessions. This ensures that when a session is started, all requests for that session are sent to the same worker appliance.
 * Configure the load balancer to test for connectivity using the {product-title_short} ping response page: `https://appliance_name/ping`. The expected reply from the appliance is the text string _pong_. Using this URL is preferable to the appliance login URL as it does not establish a connection to the database. 
 
-.Appliance configuration
-
-By default, {product-title_short} user interface worker appliances store session data in the local appliance’s memcache. When operating behind a load balancer, it is better to store the user session data in the shared database (VMDB) rather than in memcache, which is not shared. 
+==== Configuring Worker Appliances for Load Balancing
 
 When using a load balancer, configure appliances that have the *User Interface* role enabled to store session data in the database. As a result, the user does not need to re-login if the load balancer redirects them to an alternative server in case the original user interface worker is unresponsive. 
 
-Configure this using the `session_store` parameter within the advanced settings page in the {product-title_short} user interface:
+[IMPORTANT]
+====
+This configuration can cause login issues for the Self Service User Interface. If your environment uses a load balancer and access via the Self Service User Interface, do not follow the steps in this section. Instead, configure the appliances to store session data in `memcached` on one appliance, as described in xref:load-balancer-ssui-addl-config[].
+====
+
+On each appliance, configure the session data storage location using the `session_store` parameter within the advanced settings page in the {product-title_short} user interface:
 
 . From the settings menu, select *Configuration*.
 . Click the *Advanced* tab.
@@ -239,21 +242,25 @@ Configure this using the `session_store` parameter within the advanced settings 
 +
 . Click *Save*. 
 
+[IMPORTANT]
+====
 Configure the `session_store` parameter to point to `sql` on each user interface appliance behind the load balancer.
+====
+
 
 ifdef::cfme[]
-See https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.5/html-single/general_configuration/#servers[Advanced Settings] in _General Configuration_ for more information on editing configuration files from the appliance user interface.
+See https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6/html-single/general_configuration/#servers[Advanced Settings] in _General Configuration_ for more information on editing configuration files from the appliance user interface. 
 
 Also see https://access.redhat.com/documentation/en-us/reference_architectures/2017/html-single/deploying_cloudforms_at_scale/#load_balancers[Load Balancers] in the _Deploying CloudForms at Scale_ reference architecture for further information. 
 
-For information on configuring database failover in VMDB appliances, see https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6/html-single/high_availability_guide/[the _High Availability Guide_].
+For information on configuring database failover in VMDB appliances, see the https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6/html-single/high_availability_guide/[_High Availability Guide_].
 endif::cfme[]
 
 
 [[load-balancer-ssui-addl-config]]
-==== Additional Configuration for Load Balancers and the Self Service User Interface
+==== Configuring Appliances using a Load Balancer and the Self Service User Interface
 
-Running several appliances behind a load balancer can cause login issues from the Self Service user interface because `memcached`, the service storing the session in memory, is not shared between the appliances. To prevent this, configure your environment using the steps below to run the `memcached` service on one appliance and have it shared with the other appliances.
+Running several user interface worker appliances behind a load balancer can cause login issues from the Self Service user interface because `memcached`, the service storing the session in memory, is not shared between the appliances. To prevent this, configure your environment to run the `memcached` service on one appliance and have it shared with the other appliances.
 
 [IMPORTANT]
 ====
@@ -269,7 +276,7 @@ The following example shows configuration on two appliances, `appliance1` and `a
 # firewall-cmd --reload
 ----
 +
-. On `appliance1`, configure the server's advanced settings by navigating to the settings menu, selecting *Configuration*, then the *Advanced* tab:
+. From the user interface on `appliance1`, configure the server's advanced settings by navigating to the settings menu, selecting *Configuration*, then the *Advanced* tab:
 +
 ----
 :session:
@@ -277,7 +284,7 @@ The following example shows configuration on two appliances, `appliance1` and `a
   :memcache_server_opts: "-l 0.0.0.0 -I 1M"
 ----
 +
-This configures `memcached` to run on `appliance1`, but listen to all servers (-l 0.0.0.0). The `memcache_server` line, which specifies where it connects to, remains set as itself (127.0.0.1).
+This configures `memcached` to run on `appliance1`, but listen to all servers (`-l 0.0.0.0`). The `memcache_server` line, which specifies where it connects to, remains set as itself (127.0.0.1).
 +
 . Click *Save*.
 . Restart `appliance1`:
@@ -286,7 +293,7 @@ This configures `memcached` to run on `appliance1`, but listen to all servers (-
 # systemctl restart evmserverd
 ----
 
-. Configure `appliance2` to point to `appliance1` by specifying the IP address for `appliance1` in the `memcache_server` line. Configure this in the server's advanced settings by navigating to the settings menu, selecting *Configuration*, then the *Advanced* tab:
+. Configure `appliance2` to point to `appliance1` by specifying the IP address for `appliance1` in the `memcache_server` line. Configure this in the server's advanced settings from the appliance user interface, by navigating to the settings menu, selecting *Configuration*, then the *Advanced* tab:
 +
 ----
 :session:

--- a/doc-Deployment_Planning_Guide/topics/planning.adoc
+++ b/doc-Deployment_Planning_Guide/topics/planning.adoc
@@ -260,7 +260,7 @@ endif::cfme[]
 [[load-balancer-ssui-addl-config]]
 ==== Configuring Appliances using a Load Balancer and the Self Service User Interface
 
-Running several user interface worker appliances behind a load balancer can cause login issues from the Self Service user interface because `memcached`, the service storing the session in memory, is not shared between the appliances. To prevent this, configure your environment to run the `memcached` service on one appliance and have it shared with the other appliances.
+Running several user interface appliances behind a load balancer can cause login issues from the Self Service user interface because `memcached`, the service storing the session in memory, is not shared between the appliances. To prevent this, configure your environment to run the `memcached` service on one appliance and have it shared with the other appliances.
 
 [IMPORTANT]
 ====

--- a/doc-Deployment_Planning_Guide/topics/planning.adoc
+++ b/doc-Deployment_Planning_Guide/topics/planning.adoc
@@ -212,9 +212,48 @@ Providers can be added at any level of tenancy. Once added, a provider is visibl
 [[load-balancer]]
 === Using a Load Balancer
 
-Deploying several {product-title_short} appliances with a load balancer can be useful for performance.
+Deploying multiple user interface worker appliances and placing them behind a third-party load balancer allows for redundancy and improved performance. This requires extra configuration in both the load balancer and in the {product-title_short} user interface worker appliances.
 
-However, running several appliances behind a load balancer can cause login issues from the Self Service user interface because `memcached`, the service storing the session in memory, is not shared between the appliances. To prevent this, configure your environment using the steps below to run the `memcached` service on one appliance and have it shared with the other appliances.
+.Load balancer configuration
+
+* Configure the load balancer to use sticky sessions. This ensures that when a session is started, all requests for that session are sent to the same worker appliance.
+* Configure the load balancer to test for connectivity using the {product-title_short} ping response page: `https://appliance_name/ping`. The expected reply from the appliance is the text string _pong_. Using this URL is preferable to the appliance login URL as it does not establish a connection to the database. 
+
+.Appliance configuration
+
+By default, {product-title_short} user interface worker appliances store session data in the local appliance’s memcache. When operating behind a load balancer, it is better to store the user session data in the shared database (VMDB) rather than in memcache, which is not shared. 
+
+When using a load balacner, configure appliances that have the *User Interface* role enabled to store session data in the database. As a result, the user does not need to re-login if the load balancer redirects them to an alternative server in case the original user interface worker is unresponsive. 
+
+Configure this using the `session_store` parameter within the advanced settings page in the {product-title_short} user interface:
+
+. From the settings menu, select *Configuration*.
+. Click the *Advanced* tab.
+. Change the `session_store` parameter to `sql` in the following line (the default parameter is `cache`):
++
+----
+:server:
+...
+ :session_store: sql
+----
++
+. Click *Save*. 
+
+Configure the `session_store` parameter to point to `sql` on each user interface appliance behind the load balancer.
+
+ifdef::cfme[]
+See https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.5/html-single/general_configuration/#servers[Advanced Settings] in _General Configuration_ for more information on editing configuration files from the appliance user interface.
+
+Also see https://access.redhat.com/documentation/en-us/reference_architectures/2017/html-single/deploying_cloudforms_at_scale/#load_balancers[Load Balancers] in the _Deploying CloudForms at Scale_ reference architecture for further information. 
+
+For information on configuring database failover in VMDB appliances, see https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6/html-single/high_availability_guide/[the _High Availability Guide_].
+endif::cfme[]
+
+
+[[load-balancer-ssui-addl-config]]
+==== Additional Configuration for Load Balancers and the Self Service User Interface
+
+Running several appliances behind a load balancer can cause login issues from the Self Service user interface because `memcached`, the service storing the session in memory, is not shared between the appliances. To prevent this, configure your environment using the steps below to run the `memcached` service on one appliance and have it shared with the other appliances.
 
 [IMPORTANT]
 ====
@@ -265,6 +304,8 @@ This configures `memcached` to run on `appliance1`, but listen to all servers (-
 You can then get an API token from `appliance1`, and use it to access the API from `appliance2`. See https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6/html-single/red_hat_cloudforms_rest_api/#using-authentication-tokens[Using Authentication Tokens] in the _REST API_ guide for instructions.
 
 The shared `memcached` service now runs only on `appliance1`, and any other appliance accesses `memcached` from that appliance. Configure additional appliances with the steps for `appliance2`.
+
+
 
 
 

--- a/doc-Deployment_Planning_Guide/topics/planning.adoc
+++ b/doc-Deployment_Planning_Guide/topics/planning.adoc
@@ -223,7 +223,7 @@ Deploying multiple user interface worker appliances and placing them behind a th
 
 By default, {product-title_short} user interface worker appliances store session data in the local appliance’s memcache. When operating behind a load balancer, it is better to store the user session data in the shared database (VMDB) rather than in memcache, which is not shared. 
 
-When using a load balacner, configure appliances that have the *User Interface* role enabled to store session data in the database. As a result, the user does not need to re-login if the load balancer redirects them to an alternative server in case the original user interface worker is unresponsive. 
+When using a load balancer, configure appliances that have the *User Interface* role enabled to store session data in the database. As a result, the user does not need to re-login if the load balancer redirects them to an alternative server in case the original user interface worker is unresponsive. 
 
 Configure this using the `session_store` parameter within the advanced settings page in the {product-title_short} user interface:
 

--- a/doc-Deployment_Planning_Guide/topics/planning.adoc
+++ b/doc-Deployment_Planning_Guide/topics/planning.adoc
@@ -221,12 +221,7 @@ Deploying multiple user interface worker appliances and placing them behind a th
 
 ==== Configuring Worker Appliances for Load Balancing
 
-When using a load balancer, configure appliances that have the *User Interface* role enabled to store session data in the database. As a result, the user does not need to re-login if the load balancer redirects them to an alternative server in case the original user interface worker is unresponsive. 
-
-[IMPORTANT]
-====
-This configuration can cause login issues for the Self Service User Interface. If your environment uses a load balancer and access via the Self Service User Interface, do not follow the steps in this section. Instead, configure the appliances to store session data in `memcached` on one appliance, as described in xref:load-balancer-ssui-addl-config[].
-====
+When using a load balancer, configure appliances that have the *User Interface* role enabled to store session data in the database. As a result, the user does not need to re-login if the load balancer redirects them to an alternative server in the case the original user interface worker is unresponsive. 
 
 On each appliance, configure the session data storage location using the `session_store` parameter within the advanced settings page in the {product-title_short} user interface:
 
@@ -256,61 +251,6 @@ Also see https://access.redhat.com/documentation/en-us/reference_architectures/2
 For information on configuring database failover in VMDB appliances, see the https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6/html-single/high_availability_guide/[_High Availability Guide_].
 endif::cfme[]
 
-
-[[load-balancer-ssui-addl-config]]
-==== Configuring Appliances using a Load Balancer and the Self Service User Interface
-
-Running several user interface appliances behind a load balancer can cause login issues from the Self Service user interface because `memcached`, the service storing the session in memory, is not shared between the appliances. To prevent this, configure your environment to run the `memcached` service on one appliance and have it shared with the other appliances.
-
-[IMPORTANT]
-====
-When using this configuration, always start the appliance that owns `memcached` first, and ensure that `memcached` is running before starting the additional appliances. Starting another appliance before the `memcached` appliance may result in starting or login issues.
-====
-
-The following example shows configuration on two appliances, `appliance1` and `appliance2`:
-
-. On `appliance1`, open the 11211 port in the firewall:
-+
-----
-# firewall-cmd --add-port=11211/tcp --permanent
-# firewall-cmd --reload
-----
-+
-. From the user interface on `appliance1`, configure the server's advanced settings by navigating to the settings menu, selecting *Configuration*, then the *Advanced* tab:
-+
-----
-:session:
-  :memcache_server: 127.0.0.1:11211
-  :memcache_server_opts: "-l 0.0.0.0 -I 1M"
-----
-+
-This configures `memcached` to run on `appliance1`, but listen to all servers (`-l 0.0.0.0`). The `memcache_server` line, which specifies where it connects to, remains set as itself (127.0.0.1).
-+
-. Click *Save*.
-. Restart `appliance1`:
-+
-----
-# systemctl restart evmserverd
-----
-
-. Configure `appliance2` to point to `appliance1` by specifying the IP address for `appliance1` in the `memcache_server` line. Configure this in the server's advanced settings from the appliance user interface, by navigating to the settings menu, selecting *Configuration*, then the *Advanced* tab:
-+
-----
-:session:
-  :memcache_server: <appliance1>:11211        
-  :memcache_server_opts: "-l 127.0.0.1 -I 1M"   
-----
-+
-. Click *Save*.
-. Restart `appliance2`:
-+
-----
-# systemctl restart evmserverd
-----
-
-You can then get an API token from `appliance1`, and use it to access the API from `appliance2`. See https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6/html-single/red_hat_cloudforms_rest_api/#using-authentication-tokens[Using Authentication Tokens] in the _REST API_ guide for instructions.
-
-The shared `memcached` service now runs only on `appliance1`, and any other appliance accesses `memcached` from that appliance. Configure additional appliances with the steps for `appliance2`.
 
 
 

--- a/doc-High_Availability_Guide/topics/HAProxy.adoc
+++ b/doc-High_Availability_Guide/topics/HAProxy.adoc
@@ -385,6 +385,17 @@ The backup node (`cf-hap2`) shows the following:
        valid_lft forever preferred_lft forever
 ------
 
-
-
 Your environment is now configured for high availability.
+
+[IMPORTANT]
+====
+The following additional configuration in the CloudForms user interface worker appliances and the load balancer are recommended for improved performance in worker appliances:
+
+* For each {product-title_short} appliance behind the load balancer, change the `session_store` setting to `sql` in the appliance's advanced settings.
+* Configure sticky sessions in the load balancer.
+* Configure the load balancer to test for appliance connectivity using the `https://appliance_name/ping` URL.
+
+ifdef::cfme[]
+See https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6/html/deployment_planning_guide/planning#load-balancer[Using a Load Balancer] in the _Deployment Planning Guide_ for more details on these configuration steps.
+endif::cfme[]
+====


### PR DESCRIPTION
Added instructions to the load balancer section in the Deployment Planning Guide for extra config; added a briefer version to the HAProxy config in the HA guide, to align content better.

I've also added links to the Gen Config guide (has instructions on editing the Advanced settings), and to the reference arch for Deploying CloudForms at Scale (just for downstream), as it also provides these instructions, plus cross-linked these two guides for a better user experience.

Any comments welcome -- I think the distinction of this config being for "user interface appliances" or "UI appliances" is important here, despite the fact that we generally don't use this term in our docs. Time to re-evaluate that perhaps?