### PR TITLE
Added SELinux command in prepping section

### DIFF
--- a/doc-Installing_on_OpenShift_Container_Platform/topics/installation.adoc
+++ b/doc-Installing_on_OpenShift_Container_Platform/topics/installation.adoc
@@ -215,6 +215,13 @@ imagePolicyConfig:
 ----
 $ systemctl restart atomic-openshift-master
 ----
+. On each OpenShift node, persistently enable the `container_manage_cgroup` SELinux boolean to allow container processes to make changes to _cgroup_ configuration:
++
+----
+# setsebool -P container_manage_cgroup on
+----
+
+
 
 
 


### PR DESCRIPTION
Hi Suyog,

Would you mind reviewing this addition and letting me know if you have any feedback?
I think it's more a preparation step than a prerequisites (the bug reporter suggested one of those two places). I added it to the end of the preparation procedure as all of those steps are done in OpenShift. Reading through the attached cases mentioned this needs enabling on each OpenShift node also.

Here's a preview of where it sits in this guide (https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6/html/installing_red_hat_cloudforms_on_openshift_container_platform/installing-cloudforms):

![setsebool](https://user-images.githubusercontent.com/20275317/40290619-81a0bf84-5d02-11e8-8dc6-6e6672cee8e1.png)


Cheers,
Dayle