### PR TITLE
Update Amazon EC2 Provider Permissions 

### DIFF
--- a/doc-Managing_Providers/topics/Amazon_EC2_Manual_Role_Creation.adoc
+++ b/doc-Managing_Providers/topics/Amazon_EC2_Manual_Role_Creation.adoc
@@ -7,6 +7,6 @@ Use the following parameters:
 .. `AmazonEC2FullAccess`
 .. `AmazonS3FullAccess`
 .. `AmazonSQSFullAccess`
-. Input _smartstate_ for the *Role name*. 
+. Enter `smartstate` for the *Role name*. 
 
 Once the IAM role is created, assign the provider _Power User_ privileges as described in xref:amazon-provider-permissions[]. 

--- a/doc-Managing_Providers/topics/Amazon_EC2_Manual_Role_Creation.adoc
+++ b/doc-Managing_Providers/topics/Amazon_EC2_Manual_Role_Creation.adoc
@@ -7,6 +7,6 @@ Use the following parameters:
 .. `AmazonEC2FullAccess`
 .. `AmazonS3FullAccess`
 .. `AmazonSQSFullAccess`
-. Input "smartstate" for the *Role name*. 
+. Input _smartstate_ for the *Role name*. 
 
 Once the IAM role is created, assign the provider _Power User_ privileges as described in xref:amazon-provider-permissions[]. 

--- a/doc-Managing_Providers/topics/Amazon_EC2_Manual_Role_Creation.adoc
+++ b/doc-Managing_Providers/topics/Amazon_EC2_Manual_Role_Creation.adoc
@@ -1,4 +1,4 @@
-In certain installations, providing admin group privileges to a {product-title} SmartState Analysis instance may be prohibited.  In this situation, create an IAM role following the procedure described in link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-service.html[Creating a Role for an AWS Service (Console)] in the Amazon Web Services documentation. 
+To eliminate the need to assign _Admin_ group privileges to the Amazon EC2 provider, create an IAM role following the procedure described in link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-service.html[Creating a Role for an AWS Service (Console)] in the Amazon Web Services documentation. 
 
 Use the following parameters:
 
@@ -8,3 +8,5 @@ Use the following parameters:
 .. `AmazonS3FullAccess`
 .. `AmazonSQSFullAccess`
 . Input "smartstate" for the *Role name*. 
+
+Once the IAM role is created, assign the provider _Power User_ privileges as described in xref:amazon-provider-permissions[]. 

--- a/doc-Managing_Providers/topics/Amazon_EC2_Manual_Role_Creation.adoc
+++ b/doc-Managing_Providers/topics/Amazon_EC2_Manual_Role_Creation.adoc
@@ -1,0 +1,10 @@
+In certain installations, providing admin group privileges to a {product-title} SmartState Analysis instance may be prohibited.  In this situation, create an IAM role following the procedure described in link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-service.html[Creating a Role for an AWS Service (Console)] in the Amazon Web Services documentation. 
+
+Use the following parameters:
+
+. Select *EC2* as the service the role will use.
+. Attach the following permissions:
+.. `AmazonEC2FullAccess`
+.. `AmazonS3FullAccess`
+.. `AmazonSQSFullAccess`
+. Input "smartstate" for the *Role name*. 

--- a/doc-Managing_Providers/topics/Amazon_EC2_Providers_Permissions.adoc
+++ b/doc-Managing_Providers/topics/Amazon_EC2_Providers_Permissions.adoc
@@ -2,7 +2,18 @@
 
 = Permissions for Amazon EC2 Providers
 
+ifdef::cfme[]
 Red Hat recommends using Amazon EC2's _Power User_ Identity and Access Management (IAM) policy when adding Amazon EC2 as a cloud provider in {product-title_short}.
+This policy allows those in the _Power User_ group full access to AWS services except for user administration, meaning a {product-title_short} API user can access all of the API functionality, but cannot access or change user
+permissions.
+ 
+[NOTE]
+====
+When adding an Amazon EC2 provider in {product-title_short} with the intention to use the SmartState analysis feature, Red Hat recommends assigning _Admin_ group privileges.  For situations in which assigning the _Admin_ group is unacceptable, manually create an Amazon EC2 policy role using specific permissions. See xref:amazon-ec2-manual-role-creation[] for more information.
+====
+endif:cfme[]
+
+Use Amazon EC2's _Power User_ Identity and Access Management (IAM) policy when adding Amazon EC2 as a cloud provider in {product-title_short}.
 This policy allows those in the _Power User_ group full access to AWS services except for user administration, meaning a {product-title_short} API user can access all of the API functionality, but cannot access or change user
 permissions.
  

--- a/doc-Managing_Providers/topics/Amazon_EC2_Providers_Permissions.adoc
+++ b/doc-Managing_Providers/topics/Amazon_EC2_Providers_Permissions.adoc
@@ -3,8 +3,13 @@
 = Permissions for Amazon EC2 Providers
 
 Red Hat recommends using Amazon EC2's _Power User_ Identity and Access Management (IAM) policy when adding Amazon EC2 as a cloud provider in {product-title_short}.
-This policy allows those in the _Admin_ group full access to AWS services except for user administration, meaning a {product-title_short} API user can access all of the API functionality, but cannot access or change user
+This policy allows those in the _Power User_ group full access to AWS services except for user administration, meaning a {product-title_short} API user can access all of the API functionality, but cannot access or change user
 permissions.
+ 
+[NOTE]
+====
+When utilizing a {product-title_short} SmartState Analysis instance in EC2, Red Hat recommends adding {product-title_short} to the _Admin_ group.  For installations in which assigning the _Admin_ group is unacceptable, manually create an Amazon EC2 policy role using specific permissions. See xref:amazon-ec2-manual-role-creation[] for more information.
+====
 
 Further limiting API access limitations can limit Automate capabilities, as Automate
 scripts directly access the AWS SDK to create brand new
@@ -18,6 +23,12 @@ The AWS services primarily accessed by the {product-title_short} API include:
 * Elastic Load Balancing
 * Simple Notification Service (SNS)
 * Simple Queue Service (SQS)
+
+[[amazon-ec2-manual-role-creation]]
+== Manually Creating an Amazon EC2 Role For SmartState Analysis Instances
+
+include::Amazon_EC2_Manual_Role_Creation.adoc[]
+
 
 
 

--- a/doc-Managing_Providers/topics/Amazon_EC2_Providers_Permissions.adoc
+++ b/doc-Managing_Providers/topics/Amazon_EC2_Providers_Permissions.adoc
@@ -13,6 +13,7 @@ When adding an Amazon EC2 provider in {product-title_short} with the intention t
 ====
 endif::cfme[]
 
+ifdef::miq[]
 Use Amazon EC2's _Power User_ Identity and Access Management (IAM) policy when adding Amazon EC2 as a cloud provider in {product-title_short}.
 This policy allows those in the _Power User_ group full access to AWS services except for user administration, meaning a {product-title_short} API user can access all of the API functionality, but cannot access or change user
 permissions.
@@ -21,6 +22,7 @@ permissions.
 ====
 When adding an Amazon EC2 provider in {product-title_short} with the intention to use the SmartState analysis feature, assign _Admin_ group privileges.  For situations in which assigning the _Admin_ group is unacceptable, manually create an Amazon EC2 policy role using specific permissions. See xref:amazon-ec2-manual-role-creation[] for more information.
 ====
+endif::miq[]
 
 Further limiting API access limitations can limit Automate capabilities, as Automate
 scripts directly access the AWS SDK to create brand new

--- a/doc-Managing_Providers/topics/Amazon_EC2_Providers_Permissions.adoc
+++ b/doc-Managing_Providers/topics/Amazon_EC2_Providers_Permissions.adoc
@@ -8,7 +8,7 @@ permissions.
  
 [NOTE]
 ====
-When utilizing a {product-title_short} SmartState Analysis instance in EC2, Red Hat recommends adding {product-title_short} to the _Admin_ group.  For installations in which assigning the _Admin_ group is unacceptable, manually create an Amazon EC2 policy role using specific permissions. See xref:amazon-ec2-manual-role-creation[] for more information.
+When adding an Amazon EC2 provider in {product-title_short} with the intention to use the SmartState Analysis feature, Red Hat recommends using the _Admin_ group.  For situations in which assigning the _Admin_ group is unacceptable, manually create an Amazon EC2 policy role using specific permissions. See xref:amazon-ec2-manual-role-creation[] for more information.
 ====
 
 Further limiting API access limitations can limit Automate capabilities, as Automate
@@ -25,7 +25,7 @@ The AWS services primarily accessed by the {product-title_short} API include:
 * Simple Queue Service (SQS)
 
 [[amazon-ec2-manual-role-creation]]
-== Manually Creating an Amazon EC2 Role For SmartState Analysis Instances
+== Manually Creating an Amazon EC2 Role
 
 include::Amazon_EC2_Manual_Role_Creation.adoc[]
 

--- a/doc-Managing_Providers/topics/Amazon_EC2_Providers_Permissions.adoc
+++ b/doc-Managing_Providers/topics/Amazon_EC2_Providers_Permissions.adoc
@@ -8,7 +8,7 @@ permissions.
  
 [NOTE]
 ====
-When adding an Amazon EC2 provider in {product-title_short} with the intention to use the SmartState Analysis feature, Red Hat recommends using the _Admin_ group.  For situations in which assigning the _Admin_ group is unacceptable, manually create an Amazon EC2 policy role using specific permissions. See xref:amazon-ec2-manual-role-creation[] for more information.
+When adding an Amazon EC2 provider in {product-title_short} with the intention to use the SmartState analysis feature, assign _Admin_ group privileges.  For situations in which assigning the _Admin_ group is unacceptable, manually create an Amazon EC2 policy role using specific permissions. See xref:amazon-ec2-manual-role-creation[] for more information.
 ====
 
 Further limiting API access limitations can limit Automate capabilities, as Automate

--- a/doc-Managing_Providers/topics/Amazon_EC2_Providers_Permissions.adoc
+++ b/doc-Managing_Providers/topics/Amazon_EC2_Providers_Permissions.adoc
@@ -11,7 +11,7 @@ permissions.
 ====
 When adding an Amazon EC2 provider in {product-title_short} with the intention to use the SmartState analysis feature, Red Hat recommends assigning _Admin_ group privileges.  For situations in which assigning the _Admin_ group is unacceptable, manually create an Amazon EC2 policy role using specific permissions. See xref:amazon-ec2-manual-role-creation[] for more information.
 ====
-endif:cfme[]
+endif::cfme[]
 
 Use Amazon EC2's _Power User_ Identity and Access Management (IAM) policy when adding Amazon EC2 as a cloud provider in {product-title_short}.
 This policy allows those in the _Power User_ group full access to AWS services except for user administration, meaning a {product-title_short} API user can access all of the API functionality, but cannot access or change user

--- a/doc-Managing_Providers/topics/Amazon_EC2_Providers_Permissions.adoc
+++ b/doc-Managing_Providers/topics/Amazon_EC2_Providers_Permissions.adoc
@@ -3,7 +3,7 @@
 = Permissions for Amazon EC2 Providers
 
 Red Hat recommends using Amazon EC2's _Power User_ Identity and Access Management (IAM) policy when adding Amazon EC2 as a cloud provider in {product-title_short}.
-This policy allows those in the _Power User_ group full access to AWS services except for user administration, meaning a {product-title_short} API user can access all of the API functionality, but cannot access or change user
+This policy allows those in the _Admin_ group full access to AWS services except for user administration, meaning a {product-title_short} API user can access all of the API functionality, but cannot access or change user
 permissions.
 
 Further limiting API access limitations can limit Automate capabilities, as Automate


### PR DESCRIPTION
Updated the EC2 provider permissions doc to reflect recommendations for admin group, as well as added new section on manual role creation for workaround.