### PR TITLE
Fix brackets

### DIFF
--- a/api/reference/services.adoc
+++ b/api/reference/services.adoc
@@ -500,9 +500,7 @@ POST /api/services/:id
 ----
 {
   "action" : "add_resource",
-  "resource" : {
-    { "resource" : { "href" : "http://localhost:3000/api/vms/11" } }
-  }
+  "resource" : { "resource" : { "href" : "http://localhost:3000/api/vms/11" } }
 }
 ----
 
@@ -547,9 +545,7 @@ POST /api/services/:id
 ----
 {
   "action" : "remove_resource",
-  "resource" : {
-     { "resource" : { "href" : "http://localhost:3000/api/vms/11" } }
-  }
+  "resource" : { "resource" : { "href" : "http://localhost:3000/api/vms/11" } }
 }
 ----
 


### PR DESCRIPTION
The add_resource to service body should look like this, I believe. The extra bracket breaks the call. 

Found when working on https://bugzilla.redhat.com/show_bug.cgi?id=1608958#c12