### PR TITLE
edited LDAP and external auth descriptions for confusing settings

### DIFF
--- a/doc-Managing_Authentication/topics/External_auth.adoc
+++ b/doc-Managing_Authentication/topics/External_auth.adoc
@@ -1,25 +1,26 @@
 [[external_auth]]
-= Configuring Federated Identity Management (External Authentication) with {product-title_short}
+= Configuring Identity Management (External Authentication) with {product-title_short}
 
-//Overview of federated auth in CloudForms here - benefits
 
-You can configure {product-title_short} to use federation authentication with system authentication methods such as Red Hat Identity Management (IdM), Red Hat Single Sign-On (SSO), or Active Directory (AD). 
+You can configure {product-title_short} to use federation authentication with system authentication methods such as Red Hat Identity Management (IdM) or IPA, Red Hat Single Sign-On (SSO), or Active Directory (AD). 
+
+This method uses `apache` (`httpd`) modules with web browsers to control authentication to {product-title_short}. It is the recommended authentication method to connect {product-title_short} with most identity management services.
 
 [[external_ipa_auth]]
-== Configuring Federated Authentication with IdM 
+== Configuring Federated Authentication with IPA 
 
-You can configure {product-title_short} to use Red Hat Identity Management (IdM) for federated authentication using the *External Authentication (httpd)* option in {product-title_short}.
+You can configure {product-title_short} to use IPA for federated authentication using the *External Authentication (httpd)* option in {product-title_short}.
 
-When external authentication is enabled, users can log in to the {product-title_short} appliance using their IdM server credentials. The appliance creates user accounts automatically and imports relevant information from the IdM server.
+When external authentication is enabled, users can log in to the {product-title_short} appliance using their IPA server credentials. The appliance creates user accounts automatically and imports relevant information from the IPA server.
 
-The appliance contains IdM client software for connecting to IdM servers, but it is not configured by default. External authentication is enabled by first configuring it in the web interface, then in the console.
+The appliance contains ipa client software for connecting to IPA servers, but it is not configured by default. External authentication is enabled by first configuring it in the web interface, then in the console.
 Disabling external authentication and returning to internal database authentication also requires steps in both the web interface and the console.
 
 === External Authentication Requirements
 
-* For an appliance to leverage an IdM server on the network, both the appliance and the IdM server must have their clocks synchronized or Kerberos and LDAP authentication fail.
-* The IdM server must be known by DNS and accessible by name. If DNS is not configured accordingly, the hosts files need to be updated to reflect both IdM server and the appliance on both virtual machines.
-* For users to log in to the appliance using IdM server credentials, they must be members of at least one group on the IdM server which is also defined in the appliance. Navigate to the settings menu, then menu:Configuration[Access Control > Groups] to administer groups.
+* For an appliance to leverage an IPA server on the network, both the appliance and the IPA server must have their clocks synchronized or Kerberos and LDAP authentication fail.
+* The IPA server must be known by DNS and accessible by name. If DNS is not configured accordingly, the hosts files need to be updated to reflect both IPA server and the appliance on both virtual machines.
+* For users to log in to the appliance using IPA server credentials, they must be members of at least one group on the IPA server which is also defined in the appliance. Navigate to the settings menu, then menu:Configuration[Access Control > Groups] to administer groups.
 
 === Configuring the Appliance for External Authentication
 
@@ -34,7 +35,7 @@ Using the web interface:
 . Select the *Authentication* tab.
 . Select a *Session Timeout* if required.
 . Select *External (httpd)* in the *Mode list*.
-. Select *Enable Single Sign-On* to allow single sign-on using Kerberos tickets from client machines that authenticate to the same IdM server as the appliance.
+. Select *Enable Single Sign-On* to allow single sign-on using Kerberos tickets from client machines that authenticate to the same IPA server as the appliance.
 . In the *Role Settings* area, select *Get User Groups* from *External Authentication (https)*.
 . Click *Save*.
 
@@ -49,21 +50,21 @@ External Auth:  not configured
 +
 . Press Enter.
 . Select *Configure External Authentication (httpd)*.
-. Enter the fully qualified hostname of the IdM server, for example _idmserver.test.company.com_.
-. Enter the IdM server domain, for example _test.company.com_.
-. Enter the IdM server realm, for example _TEST.COMPANY.COM_.
-. Enter the IdM server principal, for example _admin_.
-. Enter the password of the IdM server principal.
+. Enter the fully qualified hostname of the IPA server, for example _ipaserver.test.company.com_.
+. Enter the IPA server domain, for example _test.company.com_.
+. Enter the IPA server realm, for example _TEST.COMPANY.COM_.
+. Enter the IPA server principal, for example _admin_.
+. Enter the password of the IPA server principal.
 . Enter `y` to proceed.
 
 [NOTE]
 ====
 If any of the following conditions are true, configuration fails:
 
-* The IdM server is not reachable by its FQDN
-* The IdM server cannot reach the appliance by its FQDN
-* The time is not synchronized between the appliance and the IdM server
-* The IdM server admin password is entered incorrectly
+* The IPA server is not reachable by its FQDN
+* The IPA server cannot reach the appliance by its FQDN
+* The time is not synchronized between the appliance and the IPA server
+* The IPA server admin password is entered incorrectly
 ====
 
 .Configuring External Authentication
@@ -71,7 +72,7 @@ If any of the following conditions are true, configuration fails:
 ----
 $ ssh root@appliance.test.company.com
 [appliance]# /bin/appliance_console_cli --host appliance.test.company.com \
-                                      --ipaserver idmserver.test.company.com \
+                                      --ipaserver ipaserver.test.company.com \
                                       --iparealm TEST.COMPANY.COM \
                                       --ipaprincipal admin \
                                       --ipapassword smartvm1
@@ -101,8 +102,8 @@ External Auth:  Id.server.FQDN
 ----
 +
 . Press `Enter`.
-. Select *Configure External Authentication (httpd)*. The currently configured IdM server hostname and domain are displayed.
-. Enter `y` to remove configuration details for the IdM client.
+. Select *Configure External Authentication (httpd)*. The currently configured IPA server hostname and domain are displayed.
+. Enter `y` to remove configuration details for the IPA client.
 
 
 .Reverting to Internal Database Authentication
@@ -121,10 +122,10 @@ Appliance console CLI command and relevant options include:
 
 ----
 /bin/appliance_console_cli --host <appliance_fqdn>
-                           --ipaserver <idm_server_fqdn>
-                           --iparealm <realm_of_idm_server>
-                           --ipaprincipal <idm_server_principal>
-                           --ipapassword <idm_server_password>
+                           --ipaserver <ipa_server_fqdn>
+                           --iparealm <realm_of_ipa_server>
+                           --ipaprincipal <ipa_server_principal>
+                           --ipapassword <ipa_server_password>
                            --uninstall-ipa4.5
 ----
 

--- a/doc-Managing_Authentication/topics/External_auth.adoc
+++ b/doc-Managing_Authentication/topics/External_auth.adoc
@@ -2,19 +2,21 @@
 = Configuring Identity Management (External Authentication) with {product-title_short}
 
 
-You can configure {product-title_short} to use federation authentication with system authentication methods such as Red Hat Identity Management (IdM) or IPA, Red Hat Single Sign-On (SSO), or Active Directory (AD). 
+You can configure {product-title_short} to use system authentication methods such as Red Hat Identity Management (IdM) or IPA, Red Hat Single Sign-On (SSO), or Active Directory (AD). 
 
 This method uses `apache` (`httpd`) modules with web browsers to control authentication to {product-title_short}. It is the recommended authentication method to connect {product-title_short} with most identity management services.
 
 [[external_ipa_auth]]
-== Configuring Federated Authentication with IPA 
+== Configuring Authentication with IPA 
 
-You can configure {product-title_short} to use IPA for federated authentication using the *External Authentication (httpd)* option in {product-title_short}.
+You can configure {product-title_short} to use IPA with the *External Authentication (httpd)* option in {product-title_short}.
 
 When external authentication is enabled, users can log in to the {product-title_short} appliance using their IPA server credentials. The appliance creates user accounts automatically and imports relevant information from the IPA server.
 
-The appliance contains ipa client software for connecting to IPA servers, but it is not configured by default. External authentication is enabled by first configuring it in the web interface, then in the console.
-Disabling external authentication and returning to internal database authentication also requires steps in both the web interface and the console.
+The appliance contains IPA client software for connecting to IPA servers, but it is not configured by default. External authentication is enabled by configuring it with the
+appliance console and enabling it the web interface.
+
+Disabling external authentication and returning to internal database authentication also requires steps in both the appliance console and the web user interface.
 
 === External Authentication Requirements
 
@@ -24,22 +26,9 @@ Disabling external authentication and returning to internal database authenticat
 
 === Configuring the Appliance for External Authentication
 
-To configure the appliance for external authentication, first set up authentication using the web interface, then using the appliance console.
+To configure the appliance for external authentication, set up authentication using the appliance console, then select the *External Authentication* option in the web user interface.
 
-Using the web interface:
-
-. Log in to the web interface as an administrative user.
-. Navigate to the settings menu, then menu:Configuration[Settings > Zone > Server > NTP Servers] or use the hosting provider of the virtual machine to synchronize the appliance's time with an NTP server.
-. From the settings menu, select *Configuration*. 
-. Select your server in the *Settings* accordion.
-. Select the *Authentication* tab.
-. Select a *Session Timeout* if required.
-. Select *External (httpd)* in the *Mode list*.
-. Select *Enable Single Sign-On* to allow single sign-on using Kerberos tickets from client machines that authenticate to the same IPA server as the appliance.
-. In the *Role Settings* area, select *Get User Groups* from *External Authentication (https)*.
-. Click *Save*.
-
-Using the console:
+Using the appliance console:
 
 . Log in to the appliance console using the user name `admin`.
 . The summary screen displays:
@@ -50,7 +39,7 @@ External Auth:  not configured
 +
 . Press Enter.
 . Select *Configure External Authentication (httpd)*.
-. Enter the fully qualified hostname of the IPA server, for example _ipaserver.test.company.com_.
+. Enter the fully qualified host name of the IPA server, for example _ipaserver.test.company.com_.
 . Enter the IPA server domain, for example _test.company.com_.
 . Enter the IPA server realm, for example _TEST.COMPANY.COM_.
 . Enter the IPA server principal, for example _admin_.
@@ -67,6 +56,8 @@ If any of the following conditions are true, configuration fails:
 * The IPA server admin password is entered incorrectly
 ====
 
+Alternatively, you can configure external authentication using the `appliance_console_cli` command instead of using the appliance console menu:
+
 .Configuring External Authentication
 ====
 ----
@@ -79,12 +70,26 @@ $ ssh root@appliance.test.company.com
 ----
 ====
 
+Finish configuring external authentication using the web user interface:
+
+. Log in to the web user interface as an administrative user.
+. Navigate to the settings menu, then menu:Configuration[Settings > Zone > Server > NTP Servers] or use the hosting provider of the virtual machine to synchronize the appliance's time with an NTP server.
+. From the settings menu, select *Configuration*. 
+. Select your server in the *Settings* accordion.
+. Select the *Authentication* tab.
+. Select a *Session Timeout* if required.
+. Select *External (httpd)* in the *Mode list*.
+. Select *Enable Single Sign-On* to allow single sign-on using Kerberos tickets from client machines that authenticate to the same IPA server as the appliance.
+. In the *Role Settings* area, select *Get User Groups* from *External Authentication (https)*.
+. Click *Save*.
+
+
 
 === Reverting to Internal Database Authentication
 
-To revert to internal database authentication, first configure authentication using the web interface, then using the console.
+To revert to internal database authentication, first configure authentication using the web user interface, then using the appliance console.
 
-Using the web interface:
+Using the web user interface:
 
 . From the settings menu, select *Configuration*. 
 . Select your server in the *Settings* accordion.
@@ -92,7 +97,7 @@ Using the web interface:
 . Select *Database* in the *Mode* list.
 . Click *Save*.
 
-Using the console:
+Using the appliance console:
 
 . Log in to the appliance console using the user name `admin`.
 . The summary screen displays:
@@ -102,7 +107,7 @@ External Auth:  Id.server.FQDN
 ----
 +
 . Press `Enter`.
-. Select *Configure External Authentication (httpd)*. The currently configured IPA server hostname and domain are displayed.
+. Select *Configure External Authentication (httpd)*. The currently configured IPA server host name and domain are displayed.
 . Enter `y` to remove configuration details for the IPA client.
 
 
@@ -131,7 +136,7 @@ Appliance console CLI command and relevant options include:
 
 
 --host::
-Updates the hostname of the appliance. If you performed this step using the console and made the necessary updates made to `/etc/hosts` if DNS is not properly configured, you can omit the `--host` option.
+Updates the host name of the appliance. If you performed this step using the console and made the necessary updates made to `/etc/hosts` if DNS is not properly configured, you can omit the `--host` option.
 
 --iparealm::
 If omitted, the `iparealm` is based on the domain name of the `ipaserver`.

--- a/doc-Managing_Authentication/topics/LDAP.adoc
+++ b/doc-Managing_Authentication/topics/LDAP.adoc
@@ -7,7 +7,7 @@ If you choose LDAP or LDAPS as your authentication mode, the required parameters
 
 [IMPORTANT]
 ====
-This procedure requires a pre-configured authentication system such as Red Hat Identity Management (IdM) or Active Directory (AD) with user groups configured.
+This procedure requires a preconfigured authentication system such as Red Hat Identity Management (IdM) or Active Directory (AD) with user groups configured.
 ====
 
 
@@ -54,20 +54,20 @@ In both LDAP and LDAPS, you can use groups from your directory service to set th
 * For LDAP users not belonging to a group:
 ** Select a {product-title_short} group from the *Default Group for Users* list. This default group can be used for all LDAP users who use LDAP for authentication only. Do not select *Get User Groups from LDAP*, which will hide the *Default Group for Users* option.
 * For LDAP users belonging to a group:
-** Check *Get User Groups from LDAP* to retrieve the user's group membership from LDAP. This looks up all groups in the directory server for the user attempting to log in. This group list is matched against the available groups configured in {product-title_short}. Once a match is found, the role associated with the matching group identifies the authority the user will have on {product-title_short}. This requires group names on the directory server to match {product-title_short} group names. Checking this box enables user records to be automatically created in {product-title_short} when a user logs in.
+** Select *Get User Groups from LDAP* to retrieve the user's group membership from LDAP. This looks up all groups in the directory server for the user attempting to log in. This group list is matched against the available groups configured in {product-title_short}. Once a match is found, the role associated with the matching group identifies the authority the user will have on {product-title_short}. This requires group names on the directory server to match {product-title_short} group names. Selecting this box enables user records to be automatically created in {product-title_short} when a user logs in.
 +
 [IMPORTANT]
 ====
-If you do not check *Get User Groups from LDAP*, the user must be defined in the VMDB using the console where the User ID is the same as the user's name in your directory service typed in lowercase.
+If you do not select *Get User Groups from LDAP*, the user must be defined in the VMDB using the console where the User ID is the same as the user's name in your directory service typed in lowercase.
 ====
-** Check *Get Groups from Home Forest* to use the LDAP groups from the LDAP user's home forest. This will allow you to discover groups on your directory server and create {product-title_short} groups based on your directory server's group names. Any user logging in will be assigned to that group. This option is only displayed when *Get User Groups from LDAP* is checked.
+** Select *Get Groups from Home Forest* to use the LDAP groups from the LDAP user's home forest. This will allow you to discover groups on your directory server and create {product-title_short} groups based on your directory server's group names. Any user logging in will be assigned to that group. This option is only displayed when *Get User Groups from LDAP* is selected.
 +
 [NOTE]
 ====
-In most environments, it is recommended to check both the *Get User Groups from LDAP* and *Get Groups from Home Forest* options.
+In most environments, it is recommended to select both the *Get User Groups from LDAP* and *Get Groups from Home Forest* options.
 ====
 +
-** Check *Follow Referrals* to look up and bind a user that exists in a domain other than the one configured in the LDAP authentication settings.
+** Select *Follow Referrals* to look up and bind a user that exists in a domain other than the one configured in the LDAP authentication settings.
 ** Specify the user name to bind to the directory server in *Bind DN*. This user must have read access to all users and groups that will be used for {product-title_short} authentication and role assignment, for example, a service account user with access to all LDAP users (named _svc-ldap_ in this example).
 ** Enter the password for the Bind DN user in *Bind Password*.
 +
@@ -93,7 +93,7 @@ To add another trusted forest:
 . From the settings menu, select *Configuration*. 
 . Select your server in the *Settings* accordion.
 . Select the *Authentication* tab.
-. Check *Get User Groups from LDAP*, and enter all items in the *Role Settings* area.
+. Select *Get User Groups from LDAP*, and enter all items in the *Role Settings* area.
 . In the *Trusted Forest Settings* area, click image:green-plus.png[](*Click to add a new forest*).
 . Enter the *LDAP Host Name*, select a *Mode*, and enter an *LDAP Port*, *Base DN*, *Bind DN*, and *Bind Password*.
 . Click *Save*.

--- a/doc-Managing_Authentication/topics/LDAP.adoc
+++ b/doc-Managing_Authentication/topics/LDAP.adoc
@@ -3,16 +3,15 @@
 
 Select *LDAP* or *LDAPS* to configure {product-title_short} authentication using Red Hat Identity Management (IdM), Active Directory, or another identity management service that uses LDAP protocol.
 
-[NOTE]
-====
-For more information about Red Hat Identity Management, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/linux_domain_identity_authentication_and_policy_guide/index[Linux Domain Identity, Authentication, and Policy Guide] and related Red Hat Enterprise Linux documentation.
-====
-
 If you choose LDAP or LDAPS as your authentication mode, the required parameters are exposed under *LDAP Settings*. Be sure to validate your settings before saving them.
 
-This procedure requires a pre-configured authentication system such as Red Hat Identity Management (IdM).
+[IMPORTANT]
+====
+This procedure requires a pre-configured authentication system such as Red Hat Identity Management (IdM) or Active Directory (AD) with user groups configured.
+====
 
-//is a user with special privileges also required?
+
+For more information about Red Hat Identity Management, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/linux_domain_identity_authentication_and_policy_guide/index[Linux Domain Identity, Authentication, and Policy Guide] and related Red Hat Enterprise Linux documentation.
 
 [[ldap_config]]
 == Configuring LDAP or LDAPS Authentication 
@@ -24,10 +23,10 @@ To configure {product-title_short} to use LDAP for authentication:
 . Select the *Authentication* tab.
 . Select a *Session Timeout* to set the period of inactivity before a user is logged out of the console.
 . Select *LDAP* or *LDAPS* from the *Mode* list. This exposes additional required parameters under *LDAP Settings*.
-. Configure your *LDAP Settings* (the following example configures an IdM LDAP server):
-* Use *LDAP Host Names* to specify the fully qualified domain names of your LDAP servers. {product-title_short} will search each host name in order until it finds one that authenticates the user. Note, {product-title_short} supports using a maximum of three possible *LDAP Host Names*.
-* Use *LDAP Port* to specify the port for your LDAP server. The default is 389 for LDAP and 636 for LDAPS.
-* From the *User Type* list, select one of the following and configure the values for your LDAP server:
+. Configure your *LDAP Settings* (the following example configures an IdM directory server):
+* Use *LDAP Host Names* to specify the fully qualified domain names of your directory servers. {product-title_short} will search each host name in order until it finds one that authenticates the user. Note, {product-title_short} supports using a maximum of three possible *LDAP Host Names*.
+* Use *LDAP Port* to specify the port for your directory server. The default is 389 for LDAP and 636 for LDAPS.
+* From the *User Type* list, select one of the following and configure the values for your directory server:
 ** *User Principal Name*: Type the user name in the format of _user@domainname_, for example, _dbright@acme.com_. (In this case, the user would log on as _dbright_.)
 ** *Email Address*: Logs in with the user's email address.
 ** *Distinguished Name* (CN=<user>): Uses the common name for the user. Be sure to enter the correct *User Suffix* and *Distinguished Name* option for your directory service implementation: for example, _cn=dan bright,ou=users,dc=acme,dc=com_. (The user logs on as _dan bright_.)
@@ -42,7 +41,7 @@ The `ldapsearch(1)` command can be used to get details of your LDAP settings. To
 
   # ldapsearch -D "cn=directory manager" -H ldap://www.acme.com:389 -b "dc=acme,dc=com" -s sub "(objectclass=*)" -w password | grep -i dbright
 
-To search for your LDAP server's distinguished name (DN) values, run:
+To search for your directory server's distinguished name (DN) values, run:
 
   # ldapsearch -D "cn=directory manager" -H ldap://www.acme.com:389 -b "dc=acme,dc=com" -s sub "(objectclass=*)" -w password
 ====
@@ -55,15 +54,21 @@ In both LDAP and LDAPS, you can use groups from your directory service to set th
 * For LDAP users not belonging to a group:
 ** Select a {product-title_short} group from the *Default Group for Users* list. This default group can be used for all LDAP users who use LDAP for authentication only. Do not select *Get User Groups from LDAP*, which will hide the *Default Group for Users* option.
 * For LDAP users belonging to a group:
-** Check *Get User Groups from LDAP* to retrieve the user's group membership from LDAP. This is used for mapping a user's authorization to a {product-title_short} role. This requires group names on the LDAP server to match {product-title_short} group names.
+** Check *Get User Groups from LDAP* to retrieve the user's group membership from LDAP. This looks up all groups in the directory server for the user attempting to log in. This group list is matched against the available groups configured in {product-title_short}. Once a match is found, the role associated with the matching group identifies the authority the user will have on {product-title_short}. This requires group names on the directory server to match {product-title_short} group names. Checking this box enables user records to be automatically created in {product-title_short} when a user logs in.
 +
 [IMPORTANT]
 ====
 If you do not check *Get User Groups from LDAP*, the user must be defined in the VMDB using the console where the User ID is the same as the user's name in your directory service typed in lowercase.
 ====
-** Check *Get Roles from Home Forest* to use the LDAP roles from the LDAP user's home forest. This will allow you to discover groups on your LDAP server and create {product-title_short} groups based on your LDAP server's group names. Any user logging in will be assigned to that group. This option is only displayed when *Get User Groups from LDAP* is checked.
+** Check *Get Groups from Home Forest* to use the LDAP groups from the LDAP user's home forest. This will allow you to discover groups on your directory server and create {product-title_short} groups based on your directory server's group names. Any user logging in will be assigned to that group. This option is only displayed when *Get User Groups from LDAP* is checked.
++
+[NOTE]
+====
+In most environments, it is recommended to check both the *Get User Groups from LDAP* and *Get Groups from Home Forest* options.
+====
++
 ** Check *Follow Referrals* to look up and bind a user that exists in a domain other than the one configured in the LDAP authentication settings.
-** Specify the user name to bind to the LDAP server in *Bind DN*. This user must have read access to all users and groups that will be used for {product-title_short} authentication and role assignment, for example, a service account user with access to all LDAP users (named _svc-ldap_ in this example).
+** Specify the user name to bind to the directory server in *Bind DN*. This user must have read access to all users and groups that will be used for {product-title_short} authentication and role assignment, for example, a service account user with access to all LDAP users (named _svc-ldap_ in this example).
 ** Enter the password for the Bind DN user in *Bind Password*.
 +
 . Click *Validate* to verify your settings.
@@ -99,19 +104,19 @@ After adding other trusted LDAP forests, you can then change the order in which 
 [[assigning_account_roles_using_ldap_groups]]
 == Assigning {product-title_short} Account Roles Using LDAP Groups
 
-After configuring LDAP authentication as described in xref:ldap_settings[], you can associate {product-title_short} account roles with your LDAP users. The LDAP server defines the groups and users for {product-title_short}, while {product-title_short} defines the account roles, and maps the roles to the privileges the LDAP user has.
+After configuring LDAP authentication as described in xref:ldap_settings[], you can associate {product-title_short} account roles with your LDAP users. The LDAP directory server defines the groups and users for {product-title_short}, while {product-title_short} defines the account roles, and maps the roles to the privileges the LDAP user has.
 
 There are two ways to associate your LDAP groups with {product-title_short} account roles:
 
 * Create groups in {product-title_short} that match your existing LDAP groups by name, and assign the groups account roles; or
-* Create groups on your LDAP server based on the default account roles in {product-title_short}.
+* Create groups on your directory server based on the default account roles in {product-title_short}.
 
 The users in your LDAP groups then inherit the {product-title_short} account roles for the LDAP group(s) they are in.
 
 The authentication process then happens as such:
 
-. _LDAPuser1_ attempts to log into {product-title_short}, so {product-title_short} queries the LDAP server to verify it knows _LDAPuser1_.
-. The LDAP server then confirms that it knows _LDAPuser1_, and provides information about the LDAP groups _LDAPuser1_ belongs to: _Group1_.
+. _LDAPuser1_ attempts to log into {product-title_short}, so {product-title_short} queries the directory server to verify it knows _LDAPuser1_.
+. The directory server then confirms that it knows _LDAPuser1_, and provides information about the LDAP groups _LDAPuser1_ belongs to: _Group1_.
 . {product-title_short} then looks up _Group1_, and discovers that _Group1_ is associated with _Role1_.
 . {product-title_short} then associates _LDAPuser1_ with _Group1_ in {product-title_short}, and then allows the user to perform tasks allowable by that role.
 
@@ -148,7 +153,7 @@ To configure the LDAP group lookup priority, see xref:ldap_lookup_priority[].
 
 === Creating LDAP Groups Based on {product-title_short} Account Roles
 
-You can also configure access control for LDAP users by creating groups on your LDAP server based on {product-title_short} user account roles.
+You can also configure access control for LDAP users by creating groups on your directory server based on {product-title_short} user account roles.
 
 Your LDAP group names must match the account role names in {product-title_short}. The LDAP users in that group are then automatically assigned to that specific account role.
 


### PR DESCRIPTION
Hi Suyog,

Would you mind reviewing and letting me know what you think of the updates here? Feedback welcome, and let me know if you have questions.

I had a chat with @jvlcek today and he provided me with info on what's happening behind the scenes with these options, and also some better wording. He's also changing the UI option for the 'Get Roles From Home Forest" as we speak to "Get Groups from Home Forest" [1] -- with any luck, we'll have the docs and the UI matched up at the same time. :)

I've made the changes we discussed, which include:

* edited the description of the "Check Get User Groups from LDAP" option
* changed "Get Roles from Home Forest" to "Get Groups from Home Forest", which Joe is changing at this moment in the UI in BZ1475891;
* changed 'LDAP server' to 'directory server' throughout as it's a more common/ better term
* added a note that you must have groups pre-configured
* added a recommendation about checking off both options (home forest and ldap groups) as there doesn't seem to be a good use case for only using one -- this is what the customer did in BZ#1602845 and then their environment didn't work.
* added a little bit to the external auth section about what's making this work (apache module)
* also, the external auth section used to say "IPA" instead of IdM and I think that was better as it's the technology instead of a product. I've changed this back in the external authentication instructions.

Preview in https://bugzilla.redhat.com/show_bug.cgi?id=1602845.

Many thanks,
Dayle

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1475891
[2] https://bugzilla.redhat.com/show_bug.cgi?id=1602845