### PR TITLE
Add Note on Additional Users

### DIFF
--- a/doc-Appliance_Hardening_Guide/topics/UI_Password.adoc
+++ b/doc-Appliance_Hardening_Guide/topics/UI_Password.adoc
@@ -7,7 +7,7 @@ After installing the appliance, change the default password of the `admin` to re
 ifdef::cfme[]
 [IMPORTANT]
 ====
-{product-title} appliances are designed for 'admin` users with `root` access. Red Hat does not recommend or support configurations with users lacking `root` access.   
+{product-title} appliances are designed for `admin` users with `root` access. Red Hat does not recommend or support {product-title_short} appliance configurations with users lacking `root` access.   
 ====
 endif::cfme[]
 

--- a/doc-Appliance_Hardening_Guide/topics/UI_Password.adoc
+++ b/doc-Appliance_Hardening_Guide/topics/UI_Password.adoc
@@ -4,6 +4,13 @@
 {product-title} uses a unique `admin` user to control all functions in the web-based user interface.
 After installing the appliance, change the default password of the `admin` to restrict administrative access to the appliance's UI.
 
+ifdef::cfme[]
+[IMPORTANT]
+====
+{product-title} appliances are designed for 'admin` users with `root` access. Red Hat does not recommend or support configurations with users lacking `root` access.   
+====
+endif::cfme[]
+
 Changing the `admin` password uses the same process as changing any standard user in the appliance.
 
 . Access the appliance through your web browser and log in.


### PR DESCRIPTION
This PR adds an udpate that  non-sysadmin (root) users with a lower level of access than root is not recommended or a supported configuration. 