### PR TITLE
Add detail on ha_admin.yml config file to HA Guide

### DIFF
--- a/doc-High_Availability_Guide/topics/Database_Failover.adoc
+++ b/doc-High_Availability_Guide/topics/Database_Failover.adoc
@@ -8,6 +8,21 @@ The failover monitor daemon must run on all of the non-database {product-title_s
 This configuration is crucial for high availability to work in your environment. If the database failover monitor is not configured, the standby database-only appliance will not react and take over operations in case of a primary database failure. 
 ====
 
+=== Failover Configuration Settings
+
+Configuration settings are located in `/var/www/miq/config/ha_admin.yml`. 
+
+Default settings:
+
+[cols="1,1,1", frame="all", options="header"]
+|===
+|Parameter|Default Value|Description|
+`failover_attempts`|10s|The number of times the `failover_monitor` will attempt to failover after discovering the connection to the current database is no longer active.
+|`db_check_frequency`|300s|The sleep interval in the monitor loop and defines how frequently the connection to the database is checked.
+|`failover_check_frequency`|60s|The sleep interval between attempting to failover additional times.
+|===
+ 
+
 [[failover_monitor]]
 === Configuring the Failover Monitor
 

--- a/doc-High_Availability_Guide/topics/Database_Failover.adoc
+++ b/doc-High_Availability_Guide/topics/Database_Failover.adoc
@@ -1,4 +1,4 @@
-git branch[[database_failover]]
+[[database_failover]]
 == Configuring Database Failover
 
 The failover monitor daemon must run on all of the non-database {product-title_short} appliances to check for failures. In case of a database failure, it modifies the database configuration accordingly.
@@ -12,16 +12,20 @@ This configuration is crucial for high availability to work in your environment.
 
 Configuration settings are located in `/var/www/miq/config/ha_admin.yml`. 
 
-Default settings:
+*Default settings*:
 
 [cols="1,1,1", frame="all", options="header"]
 |===
 |Parameter|Default Value|Description|
 `failover_attempts`|10|The number of times the `failover_monitor` will attempt to failover after discovering the connection to the current database is no longer active.
-|`db_check_frequency`|300|The sleep interval in the monitor loop and defines how frequently the connection to the database is checked.
-|`failover_check_frequency`|60|The sleep interval between attempting to failover additional times.
+|`db_check_frequency`|300s|The sleep interval in the monitor loop, it defines how frequently the connection to the database is checked.
+|`failover_check_frequency`|60s|The sleep interval between attempting to failover additional times.
 |===
- 
+
+[NOTE]
+====
+`failover_attempts` and `failover_check_frequency` determine the time limit for the cluster to elect a new primary. To produce quicker failovers, reduce the value for `failover_check_frequency` and increase the value for `failover_attempts`.  
+====
 
 [[failover_monitor]]
 === Configuring the Failover Monitor

--- a/doc-High_Availability_Guide/topics/Database_Failover.adoc
+++ b/doc-High_Availability_Guide/topics/Database_Failover.adoc
@@ -1,4 +1,4 @@
-[[database_failover]]
+git branch[[database_failover]]
 == Configuring Database Failover
 
 The failover monitor daemon must run on all of the non-database {product-title_short} appliances to check for failures. In case of a database failure, it modifies the database configuration accordingly.
@@ -17,9 +17,9 @@ Default settings:
 [cols="1,1,1", frame="all", options="header"]
 |===
 |Parameter|Default Value|Description|
-`failover_attempts`|10s|The number of times the `failover_monitor` will attempt to failover after discovering the connection to the current database is no longer active.
-|`db_check_frequency`|300s|The sleep interval in the monitor loop and defines how frequently the connection to the database is checked.
-|`failover_check_frequency`|60s|The sleep interval between attempting to failover additional times.
+`failover_attempts`|10|The number of times the `failover_monitor` will attempt to failover after discovering the connection to the current database is no longer active.
+|`db_check_frequency`|300|The sleep interval in the monitor loop and defines how frequently the connection to the database is checked.
+|`failover_check_frequency`|60|The sleep interval between attempting to failover additional times.
 |===
  
 


### PR DESCRIPTION
This PR adds a reference section describing the ha_admin.yml configuration file, along with a note regarding how to best configure for quicker failovers. 