### PR TITLE
Correct Info in Failover Note

### DIFF
--- a/doc-High_Availability_Guide/topics/Database_Failover.adoc
+++ b/doc-High_Availability_Guide/topics/Database_Failover.adoc
@@ -5,7 +5,7 @@ The failover monitor daemon must run on all of the non-database {product-title_s
 
 [IMPORTANT]
 ====
-This configuration is crucial for high availability to work in your environment. If the database failover monitor is not configured, the standby database-only appliance will not react and take over operations in case of a primary database failure. 
+This configuration is crucial for high availability to work in your environment. If the database failover monitor is not configured, application (non-database) appliances will not react to the failover event and will not be reconfigured against the new primary database host. 
 ====
 
 [[failover_monitor]]


### PR DESCRIPTION
This PR corrects the information in the note in the introduction to the Database failover section, per BZ1629241.