### PR TITLE
Add note re:config settings to adding tower provider

### DIFF
--- a/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
+++ b/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
@@ -133,6 +133,11 @@ The basic workflow when using {product-title} with an Ansible Tower provider is 
 
 To access your Ansible Tower inventory from {product-title}, you must add Ansible Tower as a provider. 
 
+[NOTE]
+====
+Ensure *ENABLE HTTP BASIC AUTH* is set to *On* in the Ansible Tower configuration settings before adding the provider. See https://docs.ansible.com/ansible-tower/latest/html/administration/configure_tower_in_tower.html[Tower Configuration] in the Ansible Tower _Administration Guide_.
+====
++
 . Navigate to menu:Automation[Ansible Tower > Explorer] and click on the *Providers* accordion tab.
 . Under image:1847.png[Configuration] *Configuration*, click  image:1862.png[Add a new Provider] *Add a new Provider*.
 


### PR DESCRIPTION
This PR adds a note to Sec 3.2.2 informing the user that a configuration setting on the provider side must first be enabled before the Tower provider can be added to the CFME inventory.