### PR TITLE
Add info about trailing slash to URL

### DIFF
--- a/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
+++ b/doc-Managing_Providers/topics/Automation_Management_Providers.adoc
@@ -135,7 +135,8 @@ To access your Ansible Tower inventory from {product-title}, you must add Ansibl
 
 [NOTE]
 ====
-Ensure *ENABLE HTTP BASIC AUTH* is set to *On* in the Ansible Tower configuration settings before adding the provider. See https://docs.ansible.com/ansible-tower/latest/html/administration/configure_tower_in_tower.html[Tower Configuration] in the Ansible Tower _Administration Guide_.
+* Ensure *ENABLE HTTP BASIC AUTH* is set to *On* in the Ansible Tower configuration settings before adding the provider. See https://docs.ansible.com/ansible-tower/latest/html/administration/configure_tower_in_tower.html[Tower Configuration] in the Ansible Tower _Administration Guide_.
+* A trailing slash is required at the end of the Ansible Tower provider URL. Adding the trailing slash to the provider URL assures successful provider refreshes. 
 ====
 
 . Navigate to menu:Automation[Ansible Tower > Explorer] and click on the *Providers* accordion tab.
@@ -147,7 +148,7 @@ image:Add_Ansible_Provider.png[Add_Ansible_Provider]
 +
 .. Enter a *Name* for the new provider.
 .. Add a *Zone* for the provider.
-.. Enter the *URL* location or IP address to the Ansible Tower server.
+.. Enter the *URL* location or IP address to the Ansible Tower server. Add a trailing slash to the end of the Ansible Tower provider URL. 
 . Select the *Verify Peer Certificate* checkbox if desired.
 . In the *Credentials* area, provide the *Username* and *Password*, and *Confirm Password*.
 . Click *Validate* to verify credentials.


### PR DESCRIPTION
This PR adds an update to the procedure in Sec. 3.2.2, Adding an Ansible Tower Provider, informing users that a trailing slash is required at the end of the Tower provider URL. An update was also added in the Note at the beginning of the section, 