### PR TITLE
Move from apache module mod_auth_kerb to mod_auth_gssapi

### DIFF
--- a/auth/active_directory.adoc
+++ b/auth/active_directory.adoc
@@ -135,22 +135,18 @@ Create the Apache configuration files
 ----
 
 Update the Apache configuration file */etc/httpd/conf.d/manageiq-external-auth.conf* as follows
-to specify the correct AD domain, and reference the Kerberos keytab appropriately.
+to reference the Kerberos keytab appropriately.
 
 ----
 ...
-
     <Location /dashboard/kerberos_authenticate>
-      AuthType           Kerberos
-      AuthName           "Kerberos Login"
-      KrbMethodNegotiate On
-      KrbMethodK5Passwd  Off
-=>    KrbAuthRealms      example.com
-=>    Krb5KeyTab         /etc/krb5.keytab
-=>    KrbServiceName     Any
+      AuthType           GSSAPI
+      AuthName           "GSSAPI Single Sign On Login"
+=>    GssapiCredStore    keytab:/etc/krb5.keytab
+      GssapiLocalName    on
       Require            pam-account httpd-auth
 
-      ErrorDocument 401  /proxy_pages/invalid_sso_credentials.js
+      ErrorDocument 401 /proxy_pages/invalid_sso_credentials.js
     </Location>
 
 ...

--- a/auth/ldap.adoc
+++ b/auth/ldap.adoc
@@ -238,27 +238,6 @@ Create the Apache configuration files
                     /etc/httpd/conf.d/manageiq-external-auth.conf
 ----
 
-Update the Apache configuration file */etc/httpd/conf.d/manageiq-external-auth.conf* as follows
-to specify the correct realm:
-
-----
-...
-
-    <Location /dashboard/kerberos_authenticate>
-      AuthType           Kerberos
-      AuthName           "Kerberos Login"
-      KrbMethodNegotiate On
-      KrbMethodK5Passwd  Off
-=>    KrbAuthRealms      example.com
-      Krb5KeyTab         /etc/http.keytab
-      Require            pam-account httpd-auth
-
-      ErrorDocument 401  /proxy_pages/invalid_sso_credentials.js
-    </Location>
-
-...
-----
-
 [[configure-selinux]]
 == Configure SELinux
 


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1610127/stories/160659028

This PR is the final  of a set that will implement moving external authentication support from
the Apache module mod_auth_kerb to mod_auth_gssapi

The below other PRs must all be merged together when this one is:

- https://github.com/ManageIQ/manageiq-appliance/pull/206
- https://github.com/ManageIQ/manageiq-appliance-build/pull/282
- https://github.com/ManageIQ/manageiq/pull/18014


