### PR TITLE
Add new infrastructure api tags

### DIFF
--- a/doc-REST_API/topics/Available_Actions.adoc
+++ b/doc-REST_API/topics/Available_Actions.adoc
@@ -1,7 +1,7 @@
 [[available-actions]]
 === Available Actions
 
-[cols="1,1,1,1", options="header"]
+[cols="1,1,1", options="header"]
 |===
 | 
 						Action
@@ -12,10 +12,8 @@
 | 
 						URL
 					
-| 
-						Example
-					
 |
+
 						Add Service Catalog
 
 | 
@@ -24,8 +22,6 @@
 | 
 						/api/service_catalogs
 
-| 
-//<xref linkend="Adding_a_Sample_Service_Catalog" />
 
 
 |
@@ -37,8 +33,7 @@
 |
 						/api/service_catalogs
 
-| 
-//<xref linkend="Adding_Multiple_Service_Catalogs" />
+
  
 |
 						Edit Service Catalog
@@ -47,10 +42,9 @@
 						POST
 
 |
-						/api/service_catalogs/<replaceable>id</replaceable>
+						/api/service_catalogs/id
 
-| 
-//<xref linkend="Edit_a_Service_Catalog" />
+
 
 
 |
@@ -62,8 +56,7 @@
 |
 						/api/service_catalogs
 
-| 
-//<xref linkend="Edit_Multiple_Service_Catalogs" />
+
  
 |
 						Automation Request
@@ -74,8 +67,7 @@
 |
 						/api/automation_requests
 
-| 
-//<xref linkend="Trigger_a_Single_Automation_Request" />
+
 
 
 |
@@ -87,8 +79,7 @@
 |
 						/api/automation_requests
 
-| 
-//<xref linkend="Trigger_Multiple_Automation_Requests" />
+
 
 
 |
@@ -98,10 +89,9 @@
 						POST
 
 |
-						/api/services/<replaceable>id</replaceable>
+						/api/services/id
 
-| 
-//<xref linkend="Edit_a_Service" />
+
  
 |
 						Edit Service via PUT
@@ -110,10 +100,9 @@
 						PUT
 
 |
-						/api/services/<replaceable>id</replaceable>
+						/api/services/id
 
-| 
-//<xref linkend="Edit_a_Service_via_a_PUT_Request" />
+
 
 
 |
@@ -123,10 +112,9 @@
 						PATCH
 
 |
-						/api/services/<replaceable>id</replaceable>
+						/api/services/id
 
-| 
-//<xref linkend="Edit_a_Service_via_a_PATCH_Request" />
+
 
 
 |
@@ -138,8 +126,7 @@
 |
 						/api/services/
 
-| 
-//<xref linkend="Edit_Multiple_Services" />
+
 
 
 |
@@ -149,23 +136,9 @@
 						POST
 
 |
-						/api/services/<replaceable>id</replaceable>/tags
-
-| 
-//<xref linkend="Assign_Tags_to_a_Service" />
+						/api/services/id/tags
 
 
-|
-						Assign a Tag by Name to a Service
-
-|
-						POST
-
-|
-						/api/services/<replaceable>id</replaceable>/tags
-
-| 
-//<xref linkend="Assign_a_Tag_by_Name_to_a_Service" />
 
 
 |
@@ -175,10 +148,21 @@
 						POST
 
 |
-						/api/services/<replaceable>id</replaceable>/tags
+						/api/services/id/tags
 
-| 
-//<xref linkend="Assign_a_Tag_by_Reference_to_a_Service" />
+
+
+
+|
+						Assign a Tag by Name to a Service
+
+|
+						POST
+
+|
+						/api/services/id/tags
+
+
 
 
 |
@@ -188,10 +172,86 @@
 						POST
 
 |
-						/api/services/<replaceable>id</replaceable>/tags
+						/api/services/id/tags
 
-| 
-//<xref linkend="Unassign_Tags" />
+
+
+|
+
+						Assign Tags to Cloud Networks
+						
+|
+
+						POST
+						
+|
+						/api/cloud_networks/id/tags
+						
+
+
+|
+
+						Assign Tags to Cloud Subnets
+						
+|
+
+						POST
+						
+|
+						/api/cloud_subnets/id/tags
+						
+
+
+|
+
+						Assign Tags to Flavors
+						
+|
+
+						POST
+						
+|
+						/api/flavors/id/tags
+						
+
+
+|
+
+						Assign Tags to Availability Zones
+						
+|
+
+						POST
+						
+|
+						/api/availability_zones/id/tags
+						
+	
+
+|
+
+						Assign Tags to Network Routers
+						
+|
+
+						POST
+						
+|
+						/api/network_routers/id/tags
+						
+
+
+|
+
+						Assign Tags to Security Groups
+						
+|
+
+						POST
+						
+|
+						/api/security_groups/id/tags
+						
 
 
 |
@@ -201,10 +261,9 @@
 						POST
 
 |
-						/api/services/<replaceable>id</replaceable>
+						/api/services/id
 
-| 
-//<xref linkend="Retire_a_Service" />
+
  
 |
 						Retire Service in Future
@@ -213,10 +272,9 @@
 						POST
 
 |
-						/api/services/<replaceable>id</replaceable>
+						/api/services/id
 
-| 
-//<xref linkend="Retire_a_Service" />
+
 
 
 |
@@ -228,8 +286,7 @@
 |
 						/api/services
 
-| 
-//<xref linkend="Retire_Multiple_Services" />
+
 
 
 |
@@ -239,9 +296,9 @@
 						DELETE
 
 |
-						/api/services/<replaceable>id</replaceable>
+						/api/services/id
 
-|
+
  
 |
 						Delete Services
@@ -252,8 +309,7 @@
 |
 						/api/services
 
-| 
-//<xref linkend="Delete_Services" />
+
 
  
 |
@@ -263,10 +319,9 @@
 						POST
 
 |
-						/api/service_templates/<replaceable>id</replaceable>
+						/api/service_templates/id
 
-| 
-//<xref linkend="Edit_a_Service_Template" />
+
 
 
 |
@@ -278,8 +333,7 @@
 |
 						/api/service_templates
 
-| 
-//<xref linkend="Edit_Multiple_Service_Templates" />
+
 
  
 |
@@ -289,10 +343,9 @@
 						POST
 
 |
-						/api/service_templates/<replaceable>id</replaceable>/tags
+						/api/service_templates/id/tags
 
-| 
-//<xref linkend="Assign_Tags_to_a_Service_Template" />
+
 
 
 |
@@ -302,10 +355,9 @@
 						POST
 
 |
-						/api/service_templates/<replaceable>id</replaceable>/tags
+						/api/service_templates/id/tags
 
-| 
-//<xref linkend="Unassign_Tags_from_a_Service_Template" />
+
 
 
 |
@@ -315,9 +367,9 @@
 						DELETE
 
 |
-						/api/service_templates/<replaceable>id</replaceable>
+						/api/service_templates/id
 
-|
+
  
 |
 						Delete Service Templates
@@ -328,8 +380,7 @@
 |
 						/api/service_templates
 
-| 
-//<xref linkend="Delete_Multiple_Service_Templates" />
+
 
 |
 						Assign Service Templates
@@ -338,10 +389,9 @@
 						POST
 
 |
-						/api/service_catalogs/<replaceable>id</replaceable>/service_templates
+						/api/service_catalogs/id/service_templates
 
-| 
-//<xref linkend="Assign_Service_Templates_to_Service_Catalogs" />
+
 
 
 |
@@ -351,10 +401,9 @@
 						POST
 
 |
-						/api/service_catalogs/<replaceable>id</replaceable>/service_templates
+						/api/service_catalogs/id/service_templates
 
-| 
-//<xref linkend="Unassign_Service_Templates_from_a_Service_Catalog" />
+
 
 |
 						Order Service
@@ -363,10 +412,9 @@
 						POST
 
 |
-						/api/service_catalogs/<replaceable>id</replaceable>/service_templates
+						/api/service_catalogs/id/service_templates
 
-| 
-//<xref linkend="Order_a_Service_from_a_Service_Catalog" />
+
 
 
 |
@@ -376,10 +424,8 @@
 						POST
 
 |
-						/api/service_catalogs/<replaceable>id</replaceable>/service_templates
+						/api/service_catalogs/id/service_templates
 
-| 
-//<xref linkend="Order_Multiple_Services_from_a_Service_Catalog" />
 
 |
 						Delete Service Catalog
@@ -388,9 +434,9 @@
 						DELETE
 
 |
-						/api/service_catalogs/<replaceable>id</replaceable>
+						/api/service_catalogs/id
 
-|
+
 
 |
 						Delete Service Catalogs
@@ -401,8 +447,7 @@
 |
 						/api/service_catalogs
 
-| 
-//<xref linkend="Delete_Multiple_Service_Catalogs" />
+
 
 
 |
@@ -414,8 +459,7 @@
 |
 						/api/provision_requests
 
-| 
-//<xref linkend="Trigger_a_Single_Provisioning_Request" />
+
 
 
 |
@@ -427,8 +471,7 @@
 |
 						/api/provision_requests
 
-| 
-//<xref linkend="Trigger_Multipe_Provisioning_Requests" />
+
 
 
 |
@@ -440,8 +483,7 @@
 |
 						/api/providers
 
-|
-//<xref linkend="Create_a_Provider" />
+
 
 |
 						Create a Provider with Compound Credentials
@@ -452,8 +494,7 @@
 |
 						/api/providers
 
-|
-//<xref linkend="Create_a_Provider_with_Compound_Credentials" />
+
 
 
 |
@@ -465,7 +506,7 @@
 |
 						/api/providers
 
-|
+
 
 |
 						Update a Provider
@@ -476,8 +517,7 @@
 |
 						/api/providers
 
-|
-//<xref linkend="Update_a_Provider" />
+
 
 |
 						Delete a Provider
@@ -488,8 +528,7 @@
 |
 						/api/providers
 
-|
-//<xref linkend="Delete_a_Provider" />
+
 
  
 |
@@ -501,8 +540,7 @@
 |
 						/api/providers
 
-|
-//<xref linkend="Deleting_Multiple_Providers" />
+
 
 |
 						Refresh a Provider
@@ -513,8 +551,7 @@
 |
 						/api/providers
 
-|
-//<xref linkend="Refresh_a_Provider" />
+
 
 |
 						Scan a VM
@@ -525,8 +562,7 @@
 |
 						/api/vms
 
-|
-//<xref linkend="Scan_a_Virtual_Machine" />
+
 
 |
 						Set Owner of a VM
@@ -537,8 +573,7 @@
 |
 						/api/vms
 
-|
-//<xref linkend="Set_the_Owner_of_a_Virtual_Machine" />
+
 
 |
 						Add a Lifecycle Event to a VM
@@ -549,8 +584,7 @@
 |
 						/api/vms
 
-|
-//<xref linkend="Add_a_Lifecycle_Event_to_a_Virtual_Machine" />
+
 
 
 |
@@ -562,8 +596,7 @@
 |
 						/api/vms
 
-|
-//<xref linkend="Add_Event" />
+
 
 |
 						Start a VM
@@ -574,8 +607,6 @@
 |
 						/api/vms
 
-|
-//<xref linkend="Start_a_Virtual_Machine" />
 
 |
 						Stop a VM
@@ -586,8 +617,7 @@
 |
 						/api/vms
 
-|
-//<xref linkend="Stop_a_Virtual_Machine" />
+
 
 |
 						Suspend a VM
@@ -598,8 +628,7 @@
 |
 						/api/vms
 
-|
-//<xref linkend="Suspend_a_Virtual_Machine" />
+
 
 |
 						Delete VMs
@@ -610,7 +639,6 @@
 |
 						/api/vms
 
-|
-//<xref linkend="Delete_Virtual_Machines" />
+
 |===
 

--- a/doc-REST_API/topics/Collection_Queries.adoc
+++ b/doc-REST_API/topics/Collection_Queries.adoc
@@ -26,6 +26,18 @@
 	
 
 | 
+
+						Cloud Networks
+|
+
+						/api/cloud_networks
+|
+
+						Cloud Subnets
+|
+						/api/cloud_subnets
+						
+|						
 	
 						Clusters
 	
@@ -82,6 +94,14 @@
 	
 
 | 
+
+						Network Routers
+						
+|
+
+						/api/network_routers
+						
+|							
 	
 						Policies
 	

--- a/doc-REST_API/topics/assign_tags_availability_zone.adoc
+++ b/doc-REST_API/topics/assign_tags_availability_zone.adoc
@@ -1,0 +1,102 @@
+[[assign-tags-to-availability-zones]]
+==== Assigning Tags to Availability Zones
+
+===== Request:
+
+------
+POST /api/availability_zones/14/tags
+------
+
+[source,json]
+------
+{
+  "action" : "assign",
+  "resources" : [
+    { "category" : "location", "name" : "london" },
+    { "category" : "department", "name" : "engineering" },
+    { "category" : "environment", "name" : "test" }
+  ]
+}
+------
+
+===== Response:
+
+[source,json]
+------
+{
+  "results": [
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'location' name:'london'",
+      "href": "https://hostname/api/availability_zones/14",
+      "tag_category": "location",
+      "tag_name": "ny"
+    },
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'department' name:'engineering'",
+      "href": "https://hostname/api/availability_zones/14",
+      "tag_category": "department",
+      "tag_name": "engineering"
+    },
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'environment' name:'test'",
+      "href": "https://hostname/api/availability_zones/14",
+      "tag_category": "environment",
+      "tag_name": "test"
+    }
+  ]
+}
+------
+
+==== Assigning Tags by Name to Availability Zones
+
+===== Request:
+
+------
+POST /api/availability_zones/14/tags
+------
+
+[source,json]
+------
+{
+  "action" : "assign",
+  "resources" : [
+    { "name" : "location/london" },
+    { "name" : "department/engineering" },
+    { "name" : "environment/test" }
+  ]
+}
+------
+
+===== Response:
+
+[source,json]
+------
+{
+  "results": [
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'location' name:'london'",
+      "href": "https://hostname/api/availability_zones/14",
+      "tag_category": "location",
+      "tag_name": "london"
+    },
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'department' name:'engineering'",
+      "href": "https://hostname/api/availability_zones/14",
+      "tag_category": "department",
+      "tag_name": "engineering"
+    },
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'environment' name:'test'",
+      "href": "https://hostname/api/availability_zones/14",
+      "tag_category": "environment",
+      "tag_name": "test"
+    }
+  ]
+}
+------

--- a/doc-REST_API/topics/assign_tags_cloud_networks.adoc
+++ b/doc-REST_API/topics/assign_tags_cloud_networks.adoc
@@ -1,0 +1,102 @@
+[[assign-tags-to-cloud-networks]]
+==== Assigning Tags to Cloud Networks
+
+===== Request:
+
+------
+POST /api/cloud_networks/223/tags
+------
+
+[source,json]
+------
+{
+  "action" : "assign",
+  "resources" : [
+    { "category" : "location", "name" : "chicago" },
+    { "category" : "department", "name" : "support" },
+    { "category" : "environment", "name" : "test" }
+  ]
+}
+------
+
+===== Response:
+
+[source,json]
+------
+{
+  "results": [
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'location' name:'chicago'",
+      "href": "https://hostname/api/cloud_networks/223",
+      "tag_category": "location",
+      "tag_name": "chicago"
+    },
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'department' name:'support'",
+      "href": "https://hostname/api/cloud_networks/223",
+      "tag_category": "department",
+      "tag_name": "support"
+    },
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'environment' name:'test'",
+      "href": "https://hostname/api/cloud_networks/223",
+      "tag_category": "environment",
+      "tag_name": "test"
+    }
+  ]
+}
+------
+
+==== Assigning Tags by Name to Cloud Networks
+
+===== Request:
+
+------
+POST /api/cloud_networks/223/tags
+------
+
+[source,json]
+------
+{
+  "action" : "assign",
+  "resources" : [
+    { "name" : "location/chicago" },
+    { "name" : "department/support" },
+    { "name" : "environment/test" }
+  ]
+}
+------
+
+===== Response:
+
+[source,json]
+------
+{
+  "results": [
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'location' name:'chicago'",
+      "href": "https://hostname/api/cloud_networks/223",
+      "tag_category": "location",
+      "tag_name": "chicago"
+    },
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'department' name:'support'",
+      "href": "https://hostname/api/cloud_networks/223",
+      "tag_category": "department",
+      "tag_name": "support"
+    },
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'environment' name:'test'",
+      "href": "https://hostname/api/cloud_networks/223",
+      "tag_category": "environment",
+      "tag_name": "test"
+    }
+  ]
+}
+------

--- a/doc-REST_API/topics/assign_tags_cloud_subnet.adoc
+++ b/doc-REST_API/topics/assign_tags_cloud_subnet.adoc
@@ -1,0 +1,102 @@
+[[assign-tags-to-a-cloud-subnets]]
+==== Assigning Tags to Cloud Subnets
+
+===== Request:
+
+------
+POST /api/cloud_subnets/7/tags
+------
+
+[source,json]
+------
+{
+  "action" : "assign",
+  "resources" : [
+    { "category" : "location", "name" : "london" },
+    { "category" : "department", "name" : "marketing" },
+    { "category" : "environment", "name" : "dev" }
+  ]
+}
+------
+
+===== Response:
+
+[source,json]
+------
+{
+  "results": [
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'location' name:'ny'",
+      "href": "https://hostname/api/cloud_subnets/7",
+      "tag_category": "location",
+      "tag_name": "ny"
+    },
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'department' name:'marketing'",
+      "href": "https://hostname/api/cloud_subnets/7",
+      "tag_category": "department",
+      "tag_name": "marketing"
+    },
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'environment' name:'dev'",
+      "href": "https://hostname/api/cloud_subnets/7",
+      "tag_category": "environment",
+      "tag_name": "dev"
+    }
+  ]
+}
+------
+
+==== Assigning Tags by Name to Cloud Subnets
+
+===== Request:
+
+------
+POST /api/cloud_subnets/7/tags
+------
+
+[source,json]
+------
+{
+  "action" : "assign",
+  "resources" : [
+    { "name" : "location/internal" },
+    { "name" : "department/marketing" },
+    { "name" : "environment/dev" }
+  ]
+}
+------
+
+===== Response:
+
+[source,json]
+------
+{
+  "results": [
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'location' name:'internal'",
+      "href": "https://hostname/api/cloud_subnets/30",
+      "tag_category": "location",
+      "tag_name": "internal"
+    },
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'department' name:'marketing'",
+      "href": "https://hostname/api/cloud_subnets/30",
+      "tag_category": "department",
+      "tag_name": "marketing"
+    },
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'environment' name:'dev'",
+      "href": "https://hostname/api/cloud_subnets/30",
+      "tag_category": "environment",
+      "tag_name": "dev"
+    }
+  ]
+}
+------

--- a/doc-REST_API/topics/assign_tags_flavors.adoc
+++ b/doc-REST_API/topics/assign_tags_flavors.adoc
@@ -1,0 +1,86 @@
+[[assign-tags-to-flavors]]
+==== Assigning Tags to Flavors
+
+===== Request:
+
+------
+POST /api/flavors/223/tags
+------
+
+[source,json]
+------
+{
+  "action" : "assign",
+  "resources" : [
+    { "category" : "owner", "name" : "production linux team" },
+    { "category" : "service level", "name" : "gold" }
+  ]
+}
+------
+
+===== Response:
+
+[source,json]
+------
+{
+  "results": [
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'owner' name:'production linux team'",
+      "href": "https://hostname/api/flavors/223",
+      "tag_category": "owner",
+      "tag_name": "production linux team"
+    },
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'service level' name:'gold'",
+      "href": "https://hostname/api/flavors/223",
+      "tag_category": "service level",
+      "tag_name": "gold"
+    }
+  ]
+}
+------
+
+==== Assigning Tags by Name to Flavors
+
+===== Request:
+
+------
+POST /api/flavors/223/tags
+------
+
+[source,json]
+------
+{
+  "action" : "assign",
+  "resources" : [
+    { "name" : "owner/production linux team" },
+    { "name" : "service level/gold" }
+  ]
+}
+------
+
+===== Response:
+
+[source,json]
+------
+{
+  "results": [
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'owner' name:'production linux team'",
+      "href": "https://hostname/api/flavors/223",
+      "tag_category": "owner",
+      "tag_name": "production linux team"
+    },
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'service level' name:'gold'",
+      "href": "https://hostname/api/flavors/223",
+      "tag_category": "service level",
+      "tag_name": "gold"
+    }
+  ]
+}
+------

--- a/doc-REST_API/topics/assign_tags_network_routers.adoc
+++ b/doc-REST_API/topics/assign_tags_network_routers.adoc
@@ -1,0 +1,86 @@
+[[assign-tags-to-network-routers]]
+==== Assigning Tags to Network Routers
+
+===== Request:
+
+------
+POST /api/network_routers/400/tags
+------
+
+[source,json]
+------
+{
+  "action" : "assign",
+  "resources" : [
+    { "category" : "network location", "name" : "cloud" },
+    { "category" : "environment", "name" : "production" }
+  ]
+}
+------
+
+===== Response:
+
+[source,json]
+------
+{
+  "results": [
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'network location' name:'cloud'",
+      "href": "https://hostname/api/network_routers/400",
+      "tag_category": "network location",
+      "tag_name": "cloud"
+    },
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'environment' name:'production'",
+      "href": "https://hostname/api/network_routers/400",
+      "tag_category": "environment",
+      "tag_name": "production"
+    }
+  ]
+}
+------
+
+==== Assigning Tags by Name to Network Routers
+
+===== Request:
+
+------
+POST /api/cloud_networks/400/tags
+------
+
+[source,json]
+------
+{
+  "action" : "assign",
+  "resources" : [
+    { "name" : "network location/cloud" },
+    { "name" : "environment/production" }
+  ]
+}
+------
+
+===== Response:
+
+[source,json]
+------
+{
+  "results": [
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'network location' name:'cloud'",
+      "href": "https://hostname/api/cloud_networks/400",
+      "tag_category": "network location",
+      "tag_name": "cloud"
+    },
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'environment' name:'production'",
+      "href": "https://hostname/api/cloud_networks/400",
+      "tag_category": "environment",
+      "tag_name": "production"
+    }
+  ]
+}
+------

--- a/doc-REST_API/topics/assign_tags_security_groups.adoc
+++ b/doc-REST_API/topics/assign_tags_security_groups.adoc
@@ -1,0 +1,103 @@
+[[assign-tags-to-a-security-groups]]
+==== Assigning Tags to Security Groups
+
+===== Request:
+
+------
+POST /api/security_groups/30/tags
+------
+
+[source,json]
+------
+{
+  "action" : "assign",
+  "resources" : [
+    { "category" : "network location", "name" : "internal" },
+    { "category" : "owner", "name" : "windows 2008 test team" },
+    { "category" : "environment", "name" : "test" }
+  ]
+}
+------
+
+===== Response:
+
+[source,json]
+------
+{
+  "results": [
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'network location' name:'internal'",
+      "href": "https://hostname/api/security_groups/30",
+      "tag_category": "network location",
+      "tag_name": "internal"
+    },
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'owner' name:'windows 2008 test team'",
+      "href": "https://hostname/api/security_groups/30",
+      "tag_category": "owner",
+      "tag_name": "windows 2008 test team"
+    },
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'environment' name:'test'",
+      "href": "https://hostname/api/security_groups/30",
+      "tag_category": "environment",
+      "tag_name": "test"
+    }
+  ]
+}
+------
+
+
+==== Assigning Tags by Name to Security Groups
+
+===== Request:
+
+------
+POST /api/security_groups/30/tags
+------
+
+[source,json]
+------
+{
+  "action" : "assign",
+  "resources" : [
+    { "name" : "network location/internal" },
+    { "name" : "owner/windows 2008 test team" },
+    { "name" : "environment/test" }
+  ]
+}
+------
+
+===== Response:
+
+[source,json]
+------
+{
+  "results": [
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'network location' name:'internal'",
+      "href": "https://hostname/api/security_groups/30",
+      "tag_category": "network location",
+      "tag_name": "internal"
+    },
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'owner' name:'windows 2008 test team'",
+      "href": "https://hostname/api/security_groups/30",
+      "tag_category": "owner",
+      "tag_name": "windows 2008 test team"
+    },
+    {
+      "success": true,
+      "message": "Assigning Tag: category:'environment' name:'test'",
+      "href": "https://hostname/api/security_groups/30",
+      "tag_category": "environment",
+      "tag_name": "test"
+    }
+  ]
+}
+------

--- a/doc-REST_API/topics/chap-Examples.adoc
+++ b/doc-REST_API/topics/chap-Examples.adoc
@@ -54,6 +54,31 @@ include::unassign_tags.adoc[]
 
 include::unassign_tags_from_service_template.adoc[]
 
+include::assign_tags_cloud_networks.adoc[]
+
+include::unassign_tags_cloud_networks.adoc[]
+
+include::assign_tags_cloud_subnet.adoc[]
+
+include::unassign_tags_cloud_subnets.adoc[]
+
+include::assign_tags_availability_zone.adoc[]
+
+include::unassign_tags_availability_zones.adoc[]
+
+include::assign_tags_flavors.adoc[]
+
+include::unassign_tags_flavors.adoc[]
+
+include::assign_tags_network_routers.adoc[]
+
+include::unassign_tags_network_routers.adoc[]
+
+include::assign_tags_security_groups.adoc[]
+
+include::unassign_tags_security_group.adoc[]
+
+
 [[_sect_automation_requests]]
 === Automation Requests
 

--- a/doc-REST_API/topics/unassign_tags_availability_zones.adoc
+++ b/doc-REST_API/topics/unassign_tags_availability_zones.adoc
@@ -1,0 +1,51 @@
+[[unassign-tags-availability-zones]]
+==== Unassigning Tags on Availability Zones
+
+===== Request:
+
+------
+POST /api/availability_zones/14/tags
+------
+
+[source,json]
+------
+{
+  "action" : "unassign",
+  "resources" : [
+    { "category" : "location", "name" : "london" },
+    { "category" : "department", "name" : "engineering" },
+    { "category" : "environment", "name" : "test" }
+  ]
+}
+------
+
+===== Response:
+
+[source,json]
+------
+{
+  "results": [
+    {
+      "success": true,
+      "message": "Unassigning Tag: category:'location' name:'london'",
+      "href": "https://hostname/api/availability_zones/14",
+      "tag_category": "location",
+      "tag_name": "london"
+    },
+    {
+      "success": true,
+      "message": "Unassigning Tag: category:'department' name:'engineering'",
+      "href": "https://hostname/api/availability_zones/14",
+      "tag_category": "department",
+      "tag_name": "engineering"
+    },
+    {
+      "success": true,
+      "message": "Unassigning Tag: category:'environment' name:'test'",
+      "href": "https://hostname/api/availability_zones/14",
+      "tag_category": "environment",
+      "tag_name": "test"
+    }
+  ]
+}
+------

--- a/doc-REST_API/topics/unassign_tags_cloud_networks.adoc
+++ b/doc-REST_API/topics/unassign_tags_cloud_networks.adoc
@@ -1,0 +1,51 @@
+[[unassign-tags-cloud-networks]]
+==== Unassigning Tags on Cloud Networks
+
+===== Request:
+
+------
+POST /api/cloud_networks/223/tags
+------
+
+[source,json]
+------
+{
+  "action" : "unassign",
+  "resources" : [
+    { "category" : "location", "name" : "chicago" },
+    { "category" : "department", "name" : "support" },
+    { "category" : "environment", "name" : "test" }
+  ]
+}
+------
+
+===== Response:
+
+[source,json]
+------
+{
+  "results": [
+    {
+      "success": true,
+      "message": "Unassigning Tag: category:'location' name:'chicago'",
+      "href": "https://hostname/api/cloud_networks/223",
+      "tag_category": "location",
+      "tag_name": "chicago"
+    },
+    {
+      "success": true,
+      "message": "Unassigning Tag: category:'department' name:'support'",
+      "href": "https://hostname/api/cloud_networks/223",
+      "tag_category": "department",
+      "tag_name": "support"
+    },
+    {
+      "success": true,
+      "message": "Unassigning Tag: category:'environment' name:'test'",
+      "href": "https://hostname/api/cloud_networks/223",
+      "tag_category": "environment",
+      "tag_name": "test"
+    }
+  ]
+}
+------

--- a/doc-REST_API/topics/unassign_tags_cloud_subnets.adoc
+++ b/doc-REST_API/topics/unassign_tags_cloud_subnets.adoc
@@ -1,0 +1,51 @@
+[[unassign-tags-cloud-subnets]]
+==== Unassigning Tags on Cloud Subnets
+
+===== Request:
+
+------
+POST /api/cloud_subnets/7/tags
+------
+
+[source,json]
+------
+{
+  "action" : "unassign",
+  "resources" : [
+    { "category" : "location", "name" : "london" },
+    { "category" : "department", "name" : "marketing" },
+    { "category" : "environment", "name" : "dev" }
+  ]
+}
+------
+
+===== Response:
+
+[source,json]
+------
+{
+  "results": [
+    {
+      "success": true,
+      "message": "Unassigning Tag: category:'location' name:'london'",
+      "href": "https://hostname/api/cloud_subnets/7",
+      "tag_category": "location",
+      "tag_name": "london"
+    },
+    {
+      "success": true,
+      "message": "Unassigning Tag: category:'department' name:'marketing'",
+      "href": "https://hostname/api/cloud_subnets/7",
+      "tag_category": "department",
+      "tag_name": "marketing"
+    },
+    {
+      "success": true,
+      "message": "Unassigning Tag: category:'environment' name:'dev'",
+      "href": "https://hostname/api/cloud_subnets/7",
+      "tag_category": "environment",
+      "tag_name": "dev"
+    }
+  ]
+}
+------

--- a/doc-REST_API/topics/unassign_tags_flavors.adoc
+++ b/doc-REST_API/topics/unassign_tags_flavors.adoc
@@ -1,0 +1,43 @@
+[[unassign-tags-flavors]]
+==== Unassigning Tags on Flavors
+
+===== Request:
+
+------
+POST /api/flavors/223/tags
+------
+
+[source,json]
+------
+{
+  "action" : "unassign",
+  "resources" : [
+    { "category" : "owner", "name" : "production linux team" },
+    { "category" : "service level", "name" : "gold" }
+  ]
+}
+------
+
+===== Response:
+
+[source,json]
+------
+{
+  "results": [
+    {
+      "success": true,
+      "message": "Unassigning Tag: category:'owner' name:'production linux team'",
+      "href": "https://hostname/api/flavors/223",
+      "tag_category": "owner",
+      "tag_name": "production linux team"
+    },
+    {
+      "success": true,
+      "message": "Unassigning Tag: category:'owner' name:'gold'",
+      "href": "https://hostname/api/flavors/223",
+      "tag_category": "service level",
+      "tag_name": "gold"
+    }
+  ]
+}
+------

--- a/doc-REST_API/topics/unassign_tags_network_routers.adoc
+++ b/doc-REST_API/topics/unassign_tags_network_routers.adoc
@@ -1,0 +1,43 @@
+[[unassign-tags-network-routers]]
+==== Unassigning Tags on Network Routers
+
+===== Request:
+
+------
+POST /api/network_routers/400/tags
+------
+
+[source,json]
+------
+{
+  "action" : "unassign",
+  "resources" : [
+    { "category" : "network location", "name" : "cloud" },
+    { "category" : "environment", "name" : "production" }
+  ]
+}
+------
+
+===== Response:
+
+[source,json]
+------
+{
+  "results": [
+    {
+      "success": true,
+      "message": "Unassigning Tag: category:'network location' name:'cloud'",
+      "href": "https://hostname/api/network_routers/400",
+      "tag_category": "network location",
+      "tag_name": "cloud"
+    },
+    {
+      "success": true,
+      "message": "Unassigning Tag: category:'environment' name:'production'",
+      "href": "https://hostname/api/network_routers/400",
+      "tag_category": "environment",
+      "tag_name": "production"
+    }
+  ]
+}
+------

--- a/doc-REST_API/topics/unassign_tags_security_group.adoc
+++ b/doc-REST_API/topics/unassign_tags_security_group.adoc
@@ -1,0 +1,51 @@
+[[unassign-tags-to-a-security-groups]]
+==== Unassigning Tags on Security Groups
+
+===== Request:
+
+------
+POST /api/security_groups/30/tags
+------
+
+[source,json]
+------
+{
+  "action" : "unassign",
+  "resources" : [
+    { "category" : "network location", "name" : "internal" },
+    { "category" : "owner", "name" : "windows 2008 test team" },
+    { "category" : "environment", "name" : "test" }
+  ]
+}
+------
+
+===== Response:
+
+[source,json]
+------
+{
+  "results": [
+    {
+      "success": true,
+      "message": "Unassigning Tag: category:'network location' name:'internal'",
+      "href": "https://hostname/api/security_groups/30",
+      "tag_category": "network location",
+      "tag_name": "internal"
+    },
+    {
+      "success": true,
+      "message": "Unassigning Tag: category:'owner' name:'windows 2008 test team'",
+      "href": "https://hostname/api/security_groups/30",
+      "tag_category": "owner",
+      "tag_name": "windows 2008 test team"
+    },
+    {
+      "success": true,
+      "message": "Unassigning Tag: category:'environment' name:'test'",
+      "href": "https://hostname/api/security_groups/30",
+      "tag_category": "environment",
+      "tag_name": "test"
+    }
+  ]
+}
+------


### PR DESCRIPTION
This PR adds API reference related to tagging for the following infrastructure elements:

-      /api/availability_zones
-      /api/cloud_networks
-       /api/cloud_subnets
-       /api/flavors
-       /api/network_routers
-       /api/security_groups

New files have been added for assigning and unassigning each element, as well as updates to the Collections Queries and Available Actions files. 

As a side editorial note, I also removed the Example column from the Available Actions file, as it had no links to examples present. Examples are provided in individual files. 