### PR TITLE
PostgreSQL 9.4 is no longer supported, replace with 9.5

### DIFF
--- a/common/configuration.adoc
+++ b/common/configuration.adoc
@@ -55,7 +55,7 @@ necessary to alter the `max_connections` setting.
 
 [NOTE]
 ====
-* {product-title} 4.x requires PostgreSQL version 9.4.
+* {product-title} requires PostgreSQL version 9.5.
 * Because the `postgresql.conf` file controls the operation of all databases managed by a single instance of PostgreSQL, do not mix {product-title} databases with other types of databases in a single PostgreSQL instance.
 ====
 

--- a/install/installing_on_rhev/Configuring_Appliance.adoc
+++ b/install/installing_on_rhev/Configuring_Appliance.adoc
@@ -113,7 +113,7 @@ Because the `postgresql.conf` file controls the operation of all databases manag
 
 [NOTE]
 ======
-{product-title} requires `PostgreSQL version 9.4`.
+{product-title} requires `PostgreSQL version 9.5`.
 ======
 
 . Start the appliance and open a terminal from your virtualization or cloud provider.


### PR DESCRIPTION
(Not sure if ManageIQ 4.x still applies to current releases, never heard that numbering.)