### PR TITLE
Remove RHV specific references

### DIFF
--- a/doc-Managing_Infrastructure_and_Inventory/topics/Snapshots.adoc
+++ b/doc-Managing_Infrastructure_and_Inventory/topics/Snapshots.adoc
@@ -1,14 +1,10 @@
 [[Snapshots]]
-= Managing Virtual Machine Snapshots (Red Hat Virtualization Virtual Machines Only)
+= Managing Virtual Machine Snapshots 
 
 A snapshot is a view of a virtual machine's operating system and applications on any or all available disks at a given point in time. Take a snapshot of a virtual machine before you make a change to it that may have unintended consequences. You can use a snapshot to return a virtual machine to a previous state.
 
-The procedures in this section apply to Red Hat Virtualization virtual machines only. View virtual machines by infrastructure providers by navigating to menu:Compute[Infrastructure > Providers].
+View virtual machines by infrastructure providers by navigating to menu:Compute[Infrastructure > Providers].
 
-[NOTE]
-====
-For more information on virtual machine snapshots in Red Hat Virtualization, see https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.2/html-single/virtual_machine_management_guide/index#sect-Snapshots[Snapshots] in the _Virtual Machine Management Guide_.
-====
 
 :leveloffset: 3
 include::Creating_a_VM_snapshot.adoc[]


### PR DESCRIPTION
This PR removes RHV Only statements from Snapshot features, as this is a shared feature with VMware now. 