### PR TITLE
Add Scan Containers API module

### DIFF
--- a/doc-REST_API/topics/Available_Actions.adoc
+++ b/doc-REST_API/topics/Available_Actions.adoc
@@ -638,7 +638,14 @@
 
 |
 						/api/vms
+						
+|
 
+						Scan a Container
+|
+						POST
+|	
+            /api/container_images 
 
 |===
 

--- a/doc-REST_API/topics/Collection_Queries.adoc
+++ b/doc-REST_API/topics/Collection_Queries.adoc
@@ -52,7 +52,11 @@
 | 	
 						/api/conditions
 	
-
+|	
+						Container Images
+|
+            /api/container_images/
+												
 | 
 	
 						Datastores

--- a/doc-REST_API/topics/chap-Examples.adoc
+++ b/doc-REST_API/topics/chap-Examples.adoc
@@ -167,12 +167,22 @@ include::edit_service_templates.adoc[]
 
 include::delete_service_templates.adoc[]
 
+
+[[_sect_containers]]
+=== Containers
+
+This section provides examples of how to interact with containers.
+
+include::scan_containers.adoc[]
+
+
 [[_sect_datastores]]
 === Datastores
 
 This section provides examples of how to interact with datastores.
 
 include::delete_datastore.adoc[]
+
 
 
 

--- a/doc-REST_API/topics/scan_containers.adoc
+++ b/doc-REST_API/topics/scan_containers.adoc
@@ -12,7 +12,14 @@ Scan containers using SmartState.
 ===== Request:
 
 ------
-GET /api/container_images/441
+POST /api/container_images/440
+------
+
+[source,json]
+------
+{
+  "action": "scan"
+}
 ------
 
 
@@ -21,35 +28,10 @@ GET /api/container_images/441
 [source,json]
 ------
 {
- "href": "https://hostname/api/container_images/441",
- "id": "441",
- "tag": "latest",
- "name": "cloudforms47/cfme-openshift-app-ui",
- "image_ref": "docker-pullable://hostname/cloudforms47/cfme-openshift-app-ui",
- "container_image_registry_id": "13",
- "ems_id": "9",
- "last_sync_on": "2018-11-01T14:59:26Z",
- "last_scan_attempt_on": "2018-11-01T14:59:25Z",
- "digest": "sha256:",
- "registered_on": null,
- "architecture": null,
- "author": null,
- "command": null,
- "entrypoint": null,
- "docker_version": null,
- "exposed_ports":{},
- "environment_variables":{},
- "size": null,
- "created_on": "2018-11-01T14:55:41Z",
- "old_ems_id": null,
- "deleted_on": null,
- "type": "ContainerImage",
-  "actions":[
-        {
-        "name": "scan",
-        "method": "post",
-        "href": "https://hostname/api/container_images/441"
-        }
-      ]
+"success": true,
+"message": "ContainerImage id:440 name:'cbud_test_cont' scanning",
+"task_id": "2133",
+"task_href": "https://<hostname>/api/tasks/2133",
+"href": "https://<hostname>/api/container_images/440"
 }
 ------

--- a/doc-REST_API/topics/scan_containers.adoc
+++ b/doc-REST_API/topics/scan_containers.adoc
@@ -1,9 +1,12 @@
 [[scan-containers]]
 ==== Scanning Containers
 
+Scan containers using SmartState.
+
 [NOTE]
 ====
-Scanning containers requires enabling the SmartProxy server role. See link:https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6/html-single/general_configuration/#servers[Servers] in the _General Configuration Guide_ for information on server roles. 
+* Scanning containers requires enabling the SmartProxy server role. See link:https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6/html-single/general_configuration/#servers[Servers] in the _General Configuration Guide_ for information on server roles. 
+* Attached OpenSCAP policies do not affect responses. 
 ====
 
 ===== Request:
@@ -18,13 +21,13 @@ GET /api/container_images/441
 [source,json]
 ------
 {
- "href": "https://hosturl/api/container_images/441",
+ "href": "https://hostname/api/container_images/441",
  "id": "441",
  "tag": "latest",
  "name": "cloudforms47/cfme-openshift-app-ui",
- "image_ref": "docker-pullable://brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/cloudforms47/cfme-openshift-app-ui",
- "container_image_registry_id": "5",
- "ems_id": "3",
+ "image_ref": "docker-pullable://hostname/cloudforms47/cfme-openshift-app-ui",
+ "container_image_registry_id": "13",
+ "ems_id": "9",
  "last_sync_on": "2018-11-01T14:59:26Z",
  "last_scan_attempt_on": "2018-11-01T14:59:25Z",
  "digest": "sha256:",
@@ -45,7 +48,7 @@ GET /api/container_images/441
         {
         "name": "scan",
         "method": "post",
-        "href": "https://host_id/api/container_images/441"
+        "href": "https://hostname/api/container_images/441"
         }
       ]
 }

--- a/doc-REST_API/topics/scan_containers.adoc
+++ b/doc-REST_API/topics/scan_containers.adoc
@@ -1,0 +1,52 @@
+[[scan-containers]]
+==== Scanning Containers
+
+[NOTE]
+====
+Scanning containers requires enabling the SmartProxy server role. See link:https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6/html-single/general_configuration/#servers[Servers] in the _General Configuration Guide_ for information on server roles. 
+====
+
+===== Request:
+
+------
+GET /api/container_images/441
+------
+
+
+===== Response:
+
+[source,json]
+------
+{
+ "href": "https://hosturl/api/container_images/441",
+ "id": "441",
+ "tag": "latest",
+ "name": "cloudforms47/cfme-openshift-app-ui",
+ "image_ref": "docker-pullable://brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/cloudforms47/cfme-openshift-app-ui",
+ "container_image_registry_id": "5",
+ "ems_id": "3",
+ "last_sync_on": "2018-11-01T14:59:26Z",
+ "last_scan_attempt_on": "2018-11-01T14:59:25Z",
+ "digest": "sha256:",
+ "registered_on": null,
+ "architecture": null,
+ "author": null,
+ "command": null,
+ "entrypoint": null,
+ "docker_version": null,
+ "exposed_ports":{},
+ "environment_variables":{},
+ "size": null,
+ "created_on": "2018-11-01T14:55:41Z",
+ "old_ems_id": null,
+ "deleted_on": null,
+ "type": "ContainerImage",
+  "actions":[
+        {
+        "name": "scan",
+        "method": "post",
+        "href": "https://host_id/api/container_images/441"
+        }
+      ]
+}
+------

--- a/doc-REST_API/topics/scan_containers.adoc
+++ b/doc-REST_API/topics/scan_containers.adoc
@@ -1,7 +1,7 @@
 [[scan-containers]]
 ==== Scanning Containers
 
-Scan containers using SmartState.
+Scan containers using SmartState Analysis.
 
 [NOTE]
 ====


### PR DESCRIPTION
This PR adds new content to the REST API guide, including a new section for Containers, and information on the /api/container_iamges call. 