### PR TITLE
Database dumps

### DIFF
--- a/common/database-dumps.adoc
+++ b/common/database-dumps.adoc
@@ -1,0 +1,46 @@
+
+Creating a database dump from the appliance console can be used to provide additional information when raising a support case. Options exist to generate a database dump excluding specified tables and to split the database dump into multiple parts.  
+
+Database dumps require name or location information based on the `Dump Output File Name` selection:
+
+[width="75%"]
+|==============
+| Local File | Location
+| Network File System (NFS)| Location 
+| Samba (SMB)|Location
+| Amazon S3| Name
+| File Transfer Protocol (FTP)|Location
+| ftp to dropbox.redhat.com|Name
+|==============
+
+
+To create a database dump:
+
+. SSH into the appliance console as `root`.
+. Press any key to continue.
+. Type `appliance_console` and press `Enter`.
+. From the Advanced Settings, select option 5, `Create a Database Dump`.
+. Select a `Dump Output File Name` from the list. 
+. Enter the location or name to save the dump file to.
++
+ifdef::cfme[]
+[IMPORTANT]
+====
+For {product-title} support select `dropbox.redhat.com`. Use the following convention for the dump output file name: case number dash (-) filename, ex: `12345-db.backup`. 
+====
+endif::cfme[]
++
+. (Optional) Select tables to exclude from the dump:
+.. Enter `Y` to exclude tables. Select `N` to skip the operation. 
+.. Enter the table names in a space-separated list:
++
+-----
+metrics_* vim_performance_states event_streams
+----- 
++
+. (Optional) Split the database dump output into multiple parts:
+.. Enter `Y` to split the database dump output. Select `N` to skip the operation. 
+.. Enter the size to split by, ex `250M` or `1G`. 
+
+The database dump is created and sent to the specified location.
+

--- a/common/introduction.adoc
+++ b/common/introduction.adoc
@@ -213,6 +213,33 @@ If you experience difficulty with a procedure described in this documentation, v
 
 Red Hat also hosts a large number of electronic mailing lists for discussion of Red Hat software and technology.
 You can find a list of publicly available mailing lists at https://www.redhat.com/mailman/listinfo. Click on the name of any mailing list to subscribe to that list or to access the list archives.
+
+==== Creating a Database Dump
+
+Creating a database dump from the appliance console can be used to provide additional information when raising a support case. Options exist to generate a database dump excluding customer specified tables and to split the database dump into multiple parts, decreasing the database dump size.  
+
+To create a database dump:
+
+. SSH into the appliance console as `root`.
+. Press any key to continue.
+. Type `appliance_console` and press `Enter`.
+. From the Advanced Settings, select option 5, `Create a Database Dump`.
+. Select a `Dump Output File Name` from the list. 
+. (Optional) Select tables to exclude from the dump:
+.. Enter `Y` to exclude tables.
+.. Enter the table names in a space-separated list:
++
+-----
+metrics_* vim_performance_states event_streams
+----- 
++
+. (Optional) Split the database dump output into multiple parts:
+.. Enter `Y` to split the database dump output.
+.. Enter the byte size to split by.
+
+The database dump is created and located in the specified file.
+
+
 endif::cfme[]
 
 

--- a/common/introduction.adoc
+++ b/common/introduction.adoc
@@ -215,32 +215,12 @@ Red Hat also hosts a large number of electronic mailing lists for discussion of 
 You can find a list of publicly available mailing lists at https://www.redhat.com/mailman/listinfo. Click on the name of any mailing list to subscribe to that list or to access the list archives.
 
 ==== Creating a Database Dump
-
-Creating a database dump from the appliance console can be used to provide additional information when raising a support case. Options exist to generate a database dump excluding customer specified tables and to split the database dump into multiple parts, decreasing the database dump size.  
-
-To create a database dump:
-
-. SSH into the appliance console as `root`.
-. Press any key to continue.
-. Type `appliance_console` and press `Enter`.
-. From the Advanced Settings, select option 5, `Create a Database Dump`.
-. Select a `Dump Output File Name` from the list. 
-. (Optional) Select tables to exclude from the dump:
-.. Enter `Y` to exclude tables.
-.. Enter the table names in a space-separated list:
-+
------
-metrics_* vim_performance_states event_streams
------ 
-+
-. (Optional) Split the database dump output into multiple parts:
-.. Enter `Y` to split the database dump output.
-.. Enter the byte size to split by.
-
-The database dump is created and located in the specified file.
+include::database-dumps.adoc[]
 
 
 endif::cfme[]
+
+
 
 
 

--- a/doc-General_Configuration/topics/Configuration.adoc
+++ b/doc-General_Configuration/topics/Configuration.adoc
@@ -3199,4 +3199,5 @@ To reset your database maintenance settings, enter *Configure Database Maintenan
 
 To configure a new database maintenance schedule, enter the *Configure Database Maintenance* menu item once again and configure the values using the dialog.
 
-
+==== Creating a Database Dump
+include::common/database-dumps.adoc[]


### PR DESCRIPTION
This PR addresses includes updates for:

- Creating a Database Dump
- Splitting a Database Dump

The update has been added under "Getting Support" in the Deployment Planning Guide, as well as to the Database Operations section of the General Configuration Guide. 