### PR TITLE
add custom button migration workflow

### DIFF
--- a/common/import-export-custom-buttons.adoc
+++ b/common/import-export-custom-buttons.adoc
@@ -1,0 +1,59 @@
+[[export-import-custom-button]]
+=== Migrating Custom Buttons
+
+This workflow demonstrates how to export custom buttons from one {product-title} appliance and import them in another {product-title_short} appliance.
+
+. Export custom buttons from the source {product-title_short} appliance:
+
+.. SSH into the {product-title} appliance as `root`.
+.. Create a temporary directory:
++
+-----
+# mkdir /tmp/custom_buttons
+-----
++
+.. Navigate to the Virtual Management Database (VMDB) directory:
++
+-----
+# vmdb
+-----
++
+.. Export custom buttons using the following `rake` command:
++
+-----
+# rake evm:export:custom_buttons -- --directory /tmp/custom_buttons
+-----
++
+.. Confirm the `yaml` file was created by navigating to the new directory:
++
+-----
+# cd /tmp/custom_buttons
+-----
++
+. Copy the directory to the target {product-title_short} appliance: 
++
+-----
+scp -r /tmp/custom_buttons/ hostname:/tmp/custom_buttons
+-----
++
+. Import custom buttons on the target {product-title_short} appliance:
+.. SSH to the target {product-title_short} appliance as `root`.
+.. Navigate to the VMDB directory:
++
+-----
+# vmdb
+-----
++
+.. Import custom buttons using the following `rake` command:
++
+-----
+# rake evm:import:custom_buttons -- --source /tmp/custom_buttons
+-----
+
+To verify successful import of custom buttons:
+
+. Log in to the target {product-title_short} appliance.
+. Navigate to menu:Automation[Automate > Customization].
+. Click *Buttons* in the accordion menu.
+
+Imported buttons will appear under the parent *Object Type*. 

--- a/doc-Scripting_Actions/cfme/master.adoc
+++ b/doc-Scripting_Actions/cfme/master.adoc
@@ -25,4 +25,9 @@ include::topics/appe_faq_flows.adoc[]
 
 include::topics/appe_provision_request.adoc[]
 
+include::topics/appe_migrate_custom_buttons.adoc[]
+
+
+
+
 

--- a/doc-Scripting_Actions/miq/index.adoc
+++ b/doc-Scripting_Actions/miq/index.adoc
@@ -24,3 +24,8 @@ include::doc-Scripting_Actions/miq/topics/appe_objects.adoc[]
 include::doc-Scripting_Actions/miq/topics/appe_faq_flows.adoc[]
 
 include::doc-Scripting_Actions/miq/topics/appe_provision_request.adoc[]
+
+include::doc-Scripting_Actions/miq/topics/appe_migrate_custom_buttons.adoc[]
+
+
+

--- a/doc-Scripting_Actions/topics/To_create_a_custom_button1.adoc
+++ b/doc-Scripting_Actions/topics/To_create_a_custom_button1.adoc
@@ -3,6 +3,11 @@
 
 This procedure shows you how to create a custom button.
 
+[NOTE]
+====
+Custom buttons can be migrated to other {product-title} appliances. See xref:export-import-custom-button[Migrating Custom Buttons] for guidance on migrating custom buttons to a new {product-title_short} appliance.
+====
+
 include::common/automate-custom-button.adoc[]
 
 The button will show in the object type you added the button to.

--- a/doc-Scripting_Actions/topics/appe_migrate_custom_buttons.adoc
+++ b/doc-Scripting_Actions/topics/appe_migrate_custom_buttons.adoc
@@ -1,0 +1,5 @@
+[appendix]
+Migrating Custom Buttons
+------------------------
+
+include::common/import-export-custom-buttons.adoc[]


### PR DESCRIPTION
This PR adds a workflow demostrating how to export custom buttons from one appliance and import them to a second appliance.