### PR TITLE
Cancel migration

### DIFF
--- a/doc-Infrastructure_Migration_Solution_Guide/cfme/doc/assembly_Migration.adoc
+++ b/doc-Infrastructure_Migration_Solution_Guide/cfme/doc/assembly_Migration.adoc
@@ -6,8 +6,11 @@ Migrating your infrastructure comprises 2 tasks:
 * xref:Creating_an_Infrastructure_Mapping[Mapping] the resources (cluster, datastore, and networks) of your source environment to your target environment and selecting virtual machines to migrate
 
 * Creating a xref:Creating_and_running_a_migration_plan[migration plan] with optional xref:Automating_pre_and_post_migration_tasks_with_ansible[automated tasks] that run before or after each virtual machine is migrated
++
+You can xref:Canceling_a_migration_plan[cancel] a migration plan that is in progress. This option allows you to retry the migration plan immediately or to schedule it in the future.
 
 include::modules/proc_Creating_an_Infrastructure_Mapping.adoc[leveloffset=+1]
 include::modules/proc_Creating_and_Running_a_Migration_Plan.adoc[leveloffset=+1]
+include::modules/proc_Canceling_a_migration_plan.adoc[leveloffset=+1]
 include::modules/con_Automating_pre_and_post_migration_tasks_with_ansible.adoc[leveloffset=+1]
 include::modules/ref_Ims_rhel_pre-migration_ansible_playbook_example.adoc[leveloffset=+2]

--- a/doc-Infrastructure_Migration_Solution_Guide/cfme/doc/assembly_Troubleshooting.adoc
+++ b/doc-Infrastructure_Migration_Solution_Guide/cfme/doc/assembly_Troubleshooting.adoc
@@ -28,8 +28,6 @@ If a migration plan fails and you are not sure of the cause, check the following
 .Migrated Virtual Machine Logs
 image:Migrated_VM_details.png[]
 
-. Create and run a new migration plan, using a xref:CSV_file[CSV file] to import the virtual machines.
-
 [[Common_issues_and_mistakes]]
 == Common Issues and Mistakes
 
@@ -47,7 +45,7 @@ Migration plan does not discover virtual machines::
 If you are migrating previously migrated virtual machines, the migration plan cannot discover them because they are marked in the CloudForms VMDB as `migrated`. You must xref:Remigrating_Virtual_Machines[remigrate the virtual machines].
 
 Incorrect attributes in the virtual machine CSV import file::
-After you correct the xref:CSV_file[CSV file], create a new migration plan, import the updated CSV file, and run the migration plan.
+Correct the xref:CSV_file[CSV file], create a new migration plan, import the updated CSV file, and run the migration plan.
 
 Migration fails immediately::
 If a migration fails immediately, before the progress bar is displayed, this is often caused by a configuration error in the environment. Check the *automation.log* file on the CloudForms appliance to determine the cause. When the cause has been resolved, you can xref:Retrying_a_Migration_Plan[retry the migration plan].

--- a/doc-Infrastructure_Migration_Solution_Guide/cfme/doc/modules/proc_Canceling_a_migration_plan.adoc
+++ b/doc-Infrastructure_Migration_Solution_Guide/cfme/doc/modules/proc_Canceling_a_migration_plan.adoc
@@ -1,0 +1,13 @@
+// assembly_Migration.adoc
+[id="Canceling_a_migration_plan"]
+= Canceling a Migration Plan
+
+You can cancel a migration plan that has started and displays the progress bars:
+
+. Click menu:Migration Plans in Progress[_Migration Plan_] to display the migration plan details.
+. Select the migration plan check box and click *Cancel Migration*.
+. Click *Cancel Migrations* to confirm the cancellation. The canceled migration appears in *Migration Plans Complete* with a red `x` indicating that the plan did not complete successfully.
+
+You can click *Retry* to run the migration plan immediately or *Schedule* to run the migration plan in the future.
+
+Click the *More Actions* button to archive, edit, or delete the migration plan.

--- a/doc-Infrastructure_Migration_Solution_Guide/cfme/doc/modules/proc_Creating_and_Running_a_Migration_Plan.adoc
+++ b/doc-Infrastructure_Migration_Solution_Guide/cfme/doc/modules/proc_Creating_and_Running_a_Migration_Plan.adoc
@@ -42,17 +42,14 @@ A virtual machine will be in the same power state (`on` or `off`) after migratio
 
 . Discover the virtual machines:
 
-* If you are using the migration plan to discover the virtual machines automatically:
-
-.. Select *Choose from a list of VMs discovered in the selected infrastructure mapping*.
-.. Click *Next*.
+* If you are migrating a small number of virtual machines, select *Choose from a list of VMs discovered in the selected infrastructure mapping* and click *Next*.
 +
 .Discovered Virtual Machines
 image:Discover_VMs.png[]
 
 * If you are importing a CSV file:
 
-.. (Optional) To validate your infrastructure mapping, select *Choose from a list of VMs discovered in the selected infrastructure mapping* and click *Next*. If your virtual machines appear in the list, the infrastructure mapping is correct. Click *Back*.
+.. (Optional) You can validate your infrastructure mapping. Select *Choose from a list of VMs discovered in the selected infrastructure mapping* and click *Next*. If your virtual machines appear in the list, the infrastructure mapping is correct. Click *Back*.
 .. Select *Import a CSV file with a list of VMs to be migrated* and click *Next*.
 .. Click *Import*, browse to the CSV file, and click *Open*.
 
@@ -66,9 +63,22 @@ image:Advanced_Options.png[]
 
 . Click *Next* to go to *Schedule*.
 
-. If you do not wish to schedule the migration to run at a certain time in the future, select *Start Migration Immediately* and click *Create*.
+. Select *Save migration plan to run later* or *Start Migration Immediately* and click *Create*.
++
+* If you selected *Save migration plan to run later*, the migration plan is saved under *Migration Plans Not Started*.
++
+To schedule the migration plan, click the *Schedule* button, select a date and time, and click *Schedule*. The plan's status is *Migration Scheduled* with the date and time.
++
+[NOTE]
+====
+If you wish to run a scheduled plan immediately, click *Migrate*.
 
-. Click *Close*. The migration plan may take some time to complete. The migration plan window displays *In Progress Plans*, the amount of data being transferred, the number of virtual machines being migrated, and the elapsed time.
+To edit or delete a schedule or plan, click the *TBD* icon (... turned sideways).
+====
+
+* If you selected *Start Migration Immediately*, the migration plan runs immediately.
++
+The migration plan may take some time to complete. The migration plan window displays *In Progress Plans*, the amount of data being transferred, the number of virtual machines being migrated, and the elapsed time.
 +
 To view the migration progress of individual virtual machines, click the migration plan name to display the migration plan details.
 +
@@ -82,7 +92,7 @@ During migration, the counter displaying the migration plan progress (in menu:Co
 [[Remigrating_Virtual_Machines]]
 .Remigrating Virtual Machines
 
-To migrate previously migrated virtual machines:
+If your migration goals change, you can remigrate previously migrated virtual machines:
 
 . Delete the target virtual machines corresponding to the source virtual machines that you are remigrating.
 . Delete the disks that were created in the target datastore during the earlier migration to free up space.

--- a/doc-Infrastructure_Migration_Solution_Guide/cfme/doc/modules/proc_Creating_and_Running_a_Migration_Plan.adoc
+++ b/doc-Infrastructure_Migration_Solution_Guide/cfme/doc/modules/proc_Creating_and_Running_a_Migration_Plan.adoc
@@ -65,7 +65,7 @@ image:Advanced_Options.png[]
 
 . Select *Save migration plan to run later* or *Start Migration Immediately* and click *Create*.
 +
-* If you selected *Save migration plan to run later*, the migration plan is saved under *Migration Plans Not Started*.
+* If you selected *Save migration plan to run later*, the migration plan is saved in *Migration Plans Not Started*.
 +
 To schedule the migration plan, click the *Schedule* button, select a date and time, and click *Schedule*. The plan's status is *Migration Scheduled* with the date and time.
 +
@@ -73,14 +73,14 @@ To schedule the migration plan, click the *Schedule* button, select a date and t
 ====
 If you wish to run a scheduled plan immediately, click *Migrate*.
 
-To edit or delete a schedule or plan, click the *TBD* icon (... turned sideways).
+To edit or delete a schedule or plan, click the *More Actions* icon.
 ====
 
 * If you selected *Start Migration Immediately*, the migration plan runs immediately.
 +
-The migration plan may take some time to complete. The migration plan window displays *In Progress Plans*, the amount of data being transferred, the number of virtual machines being migrated, and the elapsed time.
+The migration plan may take some time to complete. The migration plan displays progress bars showing the amount of data being transferred, the number of virtual machines being migrated, and the elapsed time.
 +
-To view the migration progress of individual virtual machines, click the migration plan name to display the migration plan details.
+To view the migration progress of individual virtual machines, click menu:Migration Plans in Progress[_Migration Plan_] to display the migration plan details.
 +
 [NOTE]
 ====
@@ -97,9 +97,10 @@ If your migration goals change, you can remigrate previously migrated virtual ma
 . Delete the target virtual machines corresponding to the source virtual machines that you are remigrating.
 . Delete the disks that were created in the target datastore during the earlier migration to free up space.
 . Create a xref:CSV_file[CSV file] to import the source virtual machines.
-. Create and run a new migration plan.
 +
 [NOTE]
 ====
-The virtual machines cannot be discovered automatically by the migration plan because they are marked in the CloudForms VMDB as `migrated`.
+The source virtual machines cannot be discovered automatically by the migration plan because they are marked in the CloudForms VMDB as `migrated`.
 ====
+
+. Create and run a new migration plan.


### PR DESCRIPTION
Changed beginning of "Chapter 4. Migrating the Infrastructure", adding paragraph about canceling migration.
Added new section, "4.3. Canceling a Migration Plan". 
Doc build preview: http://file.tlv.redhat.com/~apinnick/Cancel_migration_Infrastructure_Migration_Solution_Guide/#Migration