### PR TITLE
added link to User section, LDAP edits for customer bug

### DIFF
--- a/doc-Managing_Authentication/topics/LDAP.adoc
+++ b/doc-Managing_Authentication/topics/LDAP.adoc
@@ -7,9 +7,10 @@ If you choose LDAP or LDAPS as your authentication mode, the required parameters
 
 [IMPORTANT]
 ====
-This procedure requires a preconfigured authentication system such as Red Hat Identity Management (IdM) or Active Directory (AD) with user groups configured.
+This procedure requires a preconfigured authentication system such as Red Hat Identity Management (IdM) or Active Directory (AD) with user groups configured. 
 ====
 
+LDAP authentication for {product-title_short} requires group membership to be defined by the LDAP RFC 2307 schema, where group members are listed by name in the member UID attribute.
 
 For more information about Red Hat Identity Management, see the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/linux_domain_identity_authentication_and_policy_guide/index[Linux Domain Identity, Authentication, and Policy Guide] and related Red Hat Enterprise Linux documentation.
 
@@ -58,7 +59,7 @@ In both LDAP and LDAPS, you can use groups from your directory service to set th
 +
 [IMPORTANT]
 ====
-If you do not select *Get User Groups from LDAP*, the user must be defined in the VMDB using the console where the User ID is the same as the user's name in your directory service typed in lowercase.
+If you do not select *Get User Groups from LDAP*, the user must be defined in the VMDB where the User ID is the same as the user's name in your directory service typed in lowercase. See https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7-Beta/html-single/general_configuration/#creating_a_user[Creating a User] in the _General Configuration_ for steps on creating users.
 ====
 +
 [NOTE]


### PR DESCRIPTION
Hi Chris,
Would you mind having a look at the changes here and letting me know what you think?

It seems a few of the points covered by the support case (summarized in Comment 2) were already in a Note in the "Creating a User" part of the Gen Config guide too, hopefully it's all clearer with this guide linked.

I also corrected the part where it said to 'configure the user in the console'. I'm hoping most of all, the sentence about the RFC 2307 schema makes sense in wording and placement.  Feedback welcome...
https://bugzilla.redhat.com/show_bug.cgi?id=1531039

Cheers,
Dayle