### PR TITLE
[HAMMER] "managed" is not correct namespace for "belongsto" filter

### DIFF
--- a/api/reference/groups.adoc
+++ b/api/reference/groups.adoc
@@ -49,8 +49,8 @@ POST /api/groups
   "role" : { "id" : "2" },
   "tenant" : { "href" : "http://localhost:3000/api/tenants/1" },
   "filters" : {
-    "belongsto" : [ "/managed/area/1", "/managed/area/2" ],
-    "managed" : [[ "/managed/infra/1", "/managed/infra/2" ]]
+    "belongsto" : [ "/belongsto/ExtManagementSystem|provider1" ],
+    "managed" : [[ "/managed/infra/1" ]]
   }
 }
 ----
@@ -96,8 +96,8 @@ POST /api/groups/:id
   "resource" : {
     "description" : "updated_sample_group",
     "filters" : {
-      "belongsto" : [ "/managed/area/1", "/managed/area/2", "/managed/area/3" ],
-      "managed" : [[ "/managed/infra/1", "/managed/infra/2"], ["/managed/other/3"]]
+      "belongsto" : [ "/belongsto/ExtManagementSystem|provider1", "/belongsto/ExtManagementSystem|provider2" ],
+      "managed" : [[ "/managed/infra/1", "/managed/infra/2" ]]
     }
   }
 }


### PR DESCRIPTION
I think users are getting confused with the example provided and are
using "/managed/<Category/tag>" for "belongsto" filter which results
in non-accessible group.

The correct value for "belongsto" should be
"/belongsto/ExtManagementSystem/<provider-name>"

Analysis:
~~~
t1 = MiqGroup.find_by(:description => "t1")
irb(main):146:0> t1.entitlement.filters
=> {"managed"=>[["/managed/tenant/wg0001"]], "belongsto"=>["/belongsto/ExtManagementSystem|rhosp11-quickvm"]}
irb(main):147:0> t1.entitlement.get_belongsto_filters
=> ["/belongsto/ExtManagementSystem|rhosp11-quickvm"]
irb(main):148:0> t1.entitlement.get_managed_filters
=> [["/managed/tenant/wg0001"]]
~~~

Below will result in non-accessible group
~~~
t1 = MiqGroup.find_by(:description => "t1")
irb(main):149:0> t1.entitlement.filters
=> {"managed"=>[["/managed/tenant/wg0001"]], "belongsto"=>["/managed/tenant/wg0001"]}
~~~