### PR TITLE
Removing the RH Insights chapter as (classic) insights menu has been …

### DIFF
--- a/doc-General_Configuration/cfme/master.adoc
+++ b/doc-General_Configuration/cfme/master.adoc
@@ -25,8 +25,6 @@ include::topics/Smart_Proxies.adoc[]
 
 include::topics/About.adoc[]
 
-include::topics/RH_Insights.adoc[]
-
 [[appendix]]
 include::topics/appe-default-roles.adoc[]
 


### PR DESCRIPTION
…removed from CF 5.0.

Eng. BZ:  https://bugzilla.redhat.com/show_bug.cgi?id=1711855