### PR TITLE
Fixed typo in ivanchuk folder name when generating docs

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -11,7 +11,7 @@ manageiq:
       dir: master
     ivanchuk:
       name: Ivanchuk
-      dir: Ivanchuk
+      dir: ivanchuk
     hammer:
       name: Hammer
       dir: hammer


### PR DESCRIPTION
Without this we can't build the docs for the website, typo introduced in https://github.com/ManageIQ/manageiq_docs/commit/1c73603d912fb92da656e4ea03aaf8eb8b5fe867.

@miq-bot add_reviewer @Fryguy 
cc @epwinchell