### PR TITLE
Restored chapter so links will build

### DIFF
--- a/doc-Managing_Infrastructure_and_Inventory/cfme/master.adoc
+++ b/doc-Managing_Infrastructure_and_Inventory/cfme/master.adoc
@@ -32,10 +32,10 @@ include::topics/Resource_Pools.adoc[]
 :leveloffset: 1
 include::topics/Datastores.adoc[]
 
-////
+
 :leveloffset: 1
 include::topics/Data_Optimization_Features.adoc[]
-////
+
 
 :leveloffset: 1
 include::topics/PXE_Servers.adoc[]


### PR DESCRIPTION
Since I edited the Data Optimization chapter to remove mentions of the Optimize menu and Bottlenecks, it looks like we're good to restore this chapter to the guide and leave the links in so it will build.