### PR TITLE
[FINE] Remove extra brace on fine version of add_resource

### DIFF
--- a/api/reference/services.adoc
+++ b/api/reference/services.adoc
@@ -498,10 +498,12 @@ POST /api/services/:id
 [source,json]
 ----
 {
-  "action" : "add_resource",
-  "resource" : {
-    { "resource" : { "href" : "http://localhost:3000/api/vms/11" } }
-  }
+	"action": "add_resource",
+	"resource": {
+		"resource": {
+			"href": "http://localhost:3000/api/vms/11"
+		}
+	}
 }
 ----
 


### PR DESCRIPTION
I know, it doesn't matter cause it's old, but it's still wrong and I wanted it to be right.