### PR TITLE
add mac temp file to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ diag-*.png.cache
 ## Project-specific ignores
 Gemfile.lock
 
+## Mac file store
+.DS_Store


### PR DESCRIPTION
Adding this so the DS_store temp files no longer get committed when working from Atom on Mac OS.