### PR TITLE
re-added note about ha_admin.log

### DIFF
--- a/doc-High_Availability_Guide/topics/Database_Failover.adoc
+++ b/doc-High_Availability_Guide/topics/Database_Failover.adoc
@@ -34,6 +34,12 @@ Test that failover is working correctly between your databases with the followin
 ----
 # systemctl status rh-postgresql95-postgresql
 ----
++
+[NOTE]
+====
+You can check the status of the simulated failure by viewing the most recent `evm.log` log on the engine appliances.
+====
++
 . Check the appliance console summary screen for the primary database. If configured correctly, the *{product-title_abbr_uc} Database* value in the appliance console summary should have switched from the hostname of the old primary database to the hostname of the new primary on all {product-title_short} appliances.
 
 


### PR DESCRIPTION
backport. 

from 4.6 release and changed the log to evm.log, in case users are wondering where to check the failover status. I'll add this to the 5.0 release notes too