### PR TITLE
removed all mentions of Google Cloud Engine and Platform from various guides

### DIFF
--- a/api/reference/providers.adoc
+++ b/api/reference/providers.adoc
@@ -216,7 +216,6 @@ The *type* attribute specifies the supported provider class names which include:
 |===================================================
 | ManageIQ::Providers::Amazon::CloudManager
 | ManageIQ::Providers::Azure::CloudManager
-| ManageIQ::Providers::Google::CloudManager
 | ManageIQ::Providers::Hawkular::MiddlewareManager
 | ManageIQ::Providers::Kubernetes::ContainerManager
 | ManageIQ::Providers::Microsoft::InfraManager
@@ -577,29 +576,6 @@ Azure:
     "userid": "<client id>",
     "password": "<client key>"
   }
-}
-----
-
-Google Compute Engine:
-[source,json]
-----
-{
-   "name":"GCE Example",
-   "type":"ManageIQ::Providers::Google::CloudManager",
-   "provider_region":"us-central1",
-   "project":"GCE Project Name",
-   "connection_configurations":[
-      {
-         "endpoint":{
-            "role":"default"
-         },
-         "authentication":{
-            "authtype":"default",
-            "type":"AuthToken",
-            "auth_key":"<auth_key_here>"
-         }
-      }
-   ]
 }
 ----
 

--- a/doc-Appliance_Hardening_Guide/topics/Firewall.adoc
+++ b/doc-Appliance_Hardening_Guide/topics/Firewall.adoc
@@ -1699,69 +1699,6 @@ The following tables detail the ports used by {product-title} to communicate wit
 |===
 
 
-.Google Compute Engine Ports Used by CloudForms Management Engine
-[cols="1,1,1,1,1,1", frame="all", options="header"]
-|===
-|
-
-                            Initiator (CFME Role if applicable)
-
-
-|
-
-                            Receiver (CFME Role if applicable)
-
-
-|
-
-                            Application
-
-
-|
-
-                            TCP Port
-
-
-|
-
-                            UDP Port
-
-
-|
-
-                            Purpose
-
-
-|
-
-                            CFME Appliance
-
-
-|
-
-                            Google Cloud SDK
-
-
-|
-
-                            HTTPS
-
-
-|
-
-                            443
-
-
-|
-
-
-
-|
-
-			                 Communication from CFME Appliance to Google Cloud Platform resources
-
-|===
-
 
 
 

--- a/doc-Managing_Infrastructure_and_Inventory/topics/Availability_Zones.adoc
+++ b/doc-Managing_Infrastructure_and_Inventory/topics/Availability_Zones.adoc
@@ -2,7 +2,7 @@
 = Availability Zones
 
 An availability zone is a provider-specific method of grouping cloud instances and services.
-{product-title} uses Amazon EC2 regions, OpenStack Nova zones, and Google Compute Engine regions as availability zones. 
+{product-title} uses Amazon EC2 regions and OpenStack Nova zones as availability zones. 
 
 :leveloffset: 2
 include::Reviewing_an_Availability_Zone.adoc[]

--- a/doc-Managing_Infrastructure_and_Inventory/topics/Controlling_the_Power_State_of_an_Instance.adoc
+++ b/doc-Managing_Infrastructure_and_Inventory/topics/Controlling_the_Power_State_of_an_Instance.adoc
@@ -15,10 +15,5 @@ Follow this procedure to control the power states of an instance through the {pr
 
 . Click *OK*.
 
-[NOTE]
-====
-Google Compute Engine instances are limited to the following power options: *Start*, *Stop*, and *Terminate*.
-====
-
 
 

--- a/doc-Managing_Providers/topics/Cross_Providers_Insight.adoc
+++ b/doc-Managing_Providers/topics/Cross_Providers_Insight.adoc
@@ -9,11 +9,10 @@ It supports cross-linking all of the layers available in the following environme
 * Red Hat Virtualization
 * VMware vCenter
 * Amazon EC2
-* Google Cloud Engine
 
 The collected information includes all the data available in other (infrastructure or cloud) providers.
 
 [NOTE]
 ====
-For Amazon EC2 (AWS) and Google Cloud Engine (GCE) support, OpenShift must be installed using the relevant cloud provider. For more information, see the https://access.redhat.com/documentation/en/openshift-container-platform/[OpenShift Container Platform Installation and Configuration Guide], ensuring you use the desired version of OpenShift.
+For Amazon EC2 (AWS) support, OpenShift must be installed using the relevant cloud provider. For more information, see the https://access.redhat.com/documentation/en/openshift-container-platform/[OpenShift Container Platform Installation and Configuration Guide], ensuring you use the desired version of OpenShift.
 ====

--- a/doc-Managing_Providers/topics/Networking_Providers.adoc
+++ b/doc-Managing_Providers/topics/Networking_Providers.adoc
@@ -3,7 +3,7 @@
 
 In {product-title}, a network manager is an inventory of networking entities on existing cloud and infrastructure providers managed by your {product-title_short} appliance.
 
-This provider type exposes software-defined networking (SDN) providers including _OpenStack Network (Neutron)_, _Azure Network_, _Amazon EC2 Network_, and _Google Cloud Network_, which enables software-defined networking inventory collection. The OpenStack Network provider collects inventory of floating IPs from OpenStack so that IPs can be allocated without querying OpenStack database every time. Also, it refreshes all Neutron data from both OpenStack and OpenStack Infrastructure, and extracts the Neutron logic to a shared place. Note that management via the network providers configuration is currently disabled.
+This provider type exposes software-defined networking (SDN) providers including _OpenStack Network (Neutron)_, _Azure Network_, and _Amazon EC2 Network_, which enables software-defined networking inventory collection. The OpenStack Network provider collects inventory of floating IPs from OpenStack so that IPs can be allocated without querying OpenStack database every time. Also, it refreshes all Neutron data from both OpenStack and OpenStack Infrastructure, and extracts the Neutron logic to a shared place. Note that management via the network providers configuration is currently disabled.
 
 This chapter describes the different types of network managers available to {product-title_short}, and how to manage them. Network managers are discovered automatically by {product-title_short} from other connected providers. 
 

--- a/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Provisioning_Requests.adoc
+++ b/doc-Provisioning_Virtual_Machines_and_Hosts/topics/Provisioning_Requests.adoc
@@ -561,44 +561,6 @@ Request 99 in region 123 results in Request ID 123000000000099.
 
 include::common/provisioning-requests-openstack.adoc[]
 
-[[provisioning-a-google-compute-engine-instance-from-an-image]]
-==== Provisioning a Google Compute Engine Instance from an Image
-
-From Red Hat {product-title} 4.2, a Google Compute Engine instance can be provisioned. Some functionality available in other cloud providers is currently unavailable when provisioning from Google Compute Engine.
-
-. Navigate to menu:Compute[Clouds > Instances].
-. Click image:2007.png[](*Lifecycle*), then click image:1862.png[](*Provision Instances*).
-. Select an image from the list presented.
-. Click *Continue*.
-. On the *Request* tab, enter information about this provisioning request. In *Request Information*, type in at least a first and last name and an email address. This email is used to send the requester status emails during the provisioning process for items such as auto-approval, quota, provision complete, retirement, request pending approval, and request denied. The other information is optional. If the {product-title} Server is configured to use LDAP, you can use the *Look Up* button to populate the other fields based on the email address.
-+
-[NOTE]
-====
-Parameters with a * next to the label are required to submit the provisioning request. To change the required parameters, see xref:provisioning-dialogs-customizing[].
-====
-+
-. Click the *Purpose* tab to select the appropriate tags for the provisioned instance.
-. Click the *Catalog* tab for basic instance options.
-.. To change the image to use as a basis for the instance, select it from the list of images.
-.. Select the *Number of Instances* to provision.
-.. Type a *Instance Name* and *Instance Description*. For Google Compute Engine instances, the *Instance Name* cannot use upper case letters. Use a combination of lower case letters and numbers to create the name.
-. Click the *Environment* tab to select the instance's *Availability Zone* and *Cloud Network*. If no specific availability zone is required, select the *Choose Automatically* checkbox.
-. Click the *Properties* tab to set provider options such as hardware flavor and boot disk settings.
-.. Select a flavor from the *Instance Type* list.
-.. Select a *Boot Disk Size* from the list.
-. Click the *Schedule* tab to set the provisioning and retirement date and time.
-.. In *Schedule Info*, choose whether the provisioning begins upon approval, or at a specific time. If you select *Schedule*, you will be prompted to enter a date and time.
-.. In *Lifespan*, select and whether to set a retirement date. If you select a retirement period, you will be prompted for when to receive a retirement warning.
-. Click *Submit*.
-
-The provisioning request is sent for approval. For the provisioning to begin, a user with the admin, approver, or super admin account role must approve the request. The admin and super admin roles can also edit, delete, and deny the requests. You will be able to see all provisioning requests where you are either the requester or the approver.
-
-After submission, the appliance assigns each provision request a *Request ID*. If an error occurs during the approval or provisioning process, use this ID to locate the request in the appliance logs. The Request ID consists of the region associated with the request followed by the request number. As regions define a range of one trillion database IDs, this number can be several digits long.
-
-*Request ID Format*
-
-Request 99 in region 123 results in Request ID 123000000000099.
-
 
 [[provisioning-dialogs-customizing]]
 ==== Customizing Provisioning Dialogs


### PR DESCRIPTION
Including the upstream API files, for thoroughness.