### PR TITLE
Update Ansible Method and add link to export datastore classes

### DIFF
--- a/doc-Scripting_Actions/topics/Ansible_method.adoc
+++ b/doc-Scripting_Actions/topics/Ansible_method.adoc
@@ -23,6 +23,7 @@ image:../images/1862.png[image] (*Add a New Method*).
 . Select a playbook *Repository* from the list.
 .. Choose a *Playbook* to use.
 .. Select the *Machine Credential* the playbook will use when it runs.
+.. Select the *Vault Credential* to use.
 .. From the *Cloud Type* list, select a cloud provider.
 .. Choose the *Cloud Credential* that corresponds to the selected cloud type.
 . Specify the *Hosts* on which the playbook will run. Choose *Localhost* or provide unique values in the *Specify host values* field.
@@ -39,3 +40,4 @@ Input parameters become extra vars, with substitution enabled. This overcomes th
 +
 . Click *Add* when finished.
 
+Once created, a playbook method can be exported to appliances in your testing or production environments or imported in appliances in multiple regions. See <<exporting-all-datastore-classes>> to export datastore classes.

--- a/doc-Scripting_Actions/topics/Ansible_method.adoc
+++ b/doc-Scripting_Actions/topics/Ansible_method.adoc
@@ -18,7 +18,7 @@ To create a playbook automate method:
 . Click the *Methods* tab.
 . Click image:../images/1847.png[image] (*Configuration*) then,
 image:../images/1862.png[image] (*Add a New Method*).
-. In the *Main Info* area, select *playbook* from the drop-down menu.
+. In the *Main Info* area, select *Playbook* from the *Type* dropdown menu.
 . Provide a *Name* and *Display Name*.
 . Select a playbook *Repository* from the list.
 .. Choose a *Playbook* to use.
@@ -40,4 +40,4 @@ Input parameters become extra vars, with substitution enabled. This overcomes th
 +
 . Click *Add* when finished.
 
-Once created, a playbook method can be exported to appliances in your testing or production environments or imported in appliances in multiple regions. See <<exporting-all-datastore-classes>> to export datastore classes.
+Once created, a the domain including your playbook method can be exported to appliances in your testing or production environments or imported in appliances in multiple regions. See <<exporting-all-datastore-classes>> for information.


### PR DESCRIPTION
Hi Dayle,

Just a quick update here to satisfy this BZ. I've updated the Ansible Method section of documentation to include the Vault field, and added some text at the bottom informing users that this method can be exported with some reasons and a link to the relevant section. 

Please let me know what you think. 