### PR TITLE
Add example for datetime filtering

### DIFF
--- a/api/overview/filtering.adoc
+++ b/api/overview/filtering.adoc
@@ -39,11 +39,12 @@ NULL or nil can also be specified instead of quoted string
 
 
 When strings, value to be quoted in single or double quotes.
+When datetimes, only strict comparison operators are supported.
 
-Example Query VMs named sample* and return name and vendor
+Example Query VMs named sample*, created_on > 2019-09-01, and return name and vendor
 
 ----
-GET /api/vms?expand=resources&attributes=name,vendor&filter[]=name='sample%'
+GET /api/vms?expand=resources&attributes=name,vendor&filter[]=created_on>2019-09-01&filter[]=name='sample%'
 ----
 
 Example Query looking for services that are retired but have an unspecified service_id


### PR DESCRIPTION
We have no examples of datetime filtering that I could find and it'd be maybe helpful to be aware of the fact that we only support strict comparisons (https://github.com/ManageIQ/manageiq-api/commit/448fc3df5c564ce37709238f70159ed78e5d0508#diff-a177051ee2997aee42b807d1fce2c580R388)

https://bugzilla.redhat.com/show_bug.cgi?id=1749914 isn't really a bug but this would clarify it.  