### PR TITLE
Backport from #1252 - phys infrastructure in default filters section

### DIFF
--- a/doc-General_Configuration/topics/My_Settings.adoc
+++ b/doc-General_Configuration/topics/My_Settings.adoc
@@ -1,7 +1,9 @@
 [[my-settings]]
 == My Settings
 
-The options under the *My Settings* menu allow you to configure options specific to the user account with which you log in to the {product-title} user interface, such as the default view displayed on login, and personal tags. You can also configure the color scheme, and button options on the main dashboard.
+The options under the *My Settings* menu allow you to configure user interface display options specific to the user account with which you log in to {product-title}, such as the default view displayed on login, and personal tags. You can also configure the color scheme, and button options on the main dashboard.
+
+These options are available by clicking your username image:user.png[] to open the settings menu, then *My Settings*.
 
 [[visual-settings]]
 === Visual Settings
@@ -52,7 +54,6 @@ Use the following procedure to set the default start page after logging in. For 
 
 . From the settings menu, navigate to *My Settings*, then click on the *Visual* tab.
 . In the *Start Page* area, select the page to display at login.
-image:2018.png[]
 . Click *Save*.
 
 [[setting-display-settings]]
@@ -77,7 +78,7 @@ In time zones where clocks are set forward for daylight savings time, the time z
 [[default-views]]
 === Default Views
 
-The options under the *Default View* menu allow you to configure the default layout used to display individual screens in the {product-title} user interface. The options you select under this menu specify the default options for each screen, but you can also change the layout for each screen using the layout buttons on each screen.
+The options under the *Default Views* menu allow you to configure the default layout used to display individual screens in the {product-title} user interface. The options you select under this menu specify the default options for each screen, but you can also change the layout for each screen using the layout buttons on each screen.
 
 [[setting-default-views-for-the-user-interface]]
 ==== Setting Default Views for the User Interface
@@ -157,7 +158,7 @@ image:Containers.png[]
 [[default-filters]]
 === Default Filters
 
-The options the *Default Filters* menu allow you to configure the default filters displayed for your hosts, virtual machines, and templates. These settings are available to all users.
+The options in the *Default Filters* menu allow you to configure the default filters displayed for your hosts, virtual machines, and templates. These settings are available to all users.
 
 [[setting-default-filters-for-cloud]]
 ==== Setting Default Filters for Cloud
@@ -186,10 +187,19 @@ To set default filters for infrastructure components:
 . In the *Infrastructure* folder, select the default filters that you want available. Items that have changed show in blue text.
 . Click *Save*.
 
+[[setting-default-filters-for-physical-infrastructure]]
+==== Setting Default Filters for Physical Infrastructure
+
+To set default filters for physical infrastructure components:
+
+. From the settings menu, navigate to *My Settings*, then click on the *Default Filters* tab.
+. In the *Physical Infrastructure* folder, select the default filters that you want available. Items that have changed show in blue text.
+. Click *Save*.
+
 [[setting-default-filters-for-services]]
 ==== Setting Default Filters for Services
 
-To Set Default Filters for Services:
+To set default filters for services:
 
 . From the settings menu, navigate to *My Settings*, then click on the *Default Filters* tab.
 . In the *Services* folder, select the default filters that you want available. Items that have changed show in blue text.
@@ -198,7 +208,7 @@ To Set Default Filters for Services:
 [[time-profiles]]
 === Time Profiles
 
-The options under the *Time profiles* menu allow you to specify the hours for which data is displayed when viewing capacity and utilization screens. Time profiles are also used to configure performance and trend reports.
+The options under the *Time Profiles* menu allow you to specify the hours for which data is displayed when viewing capacity and utilization screens. Time profiles are also used to configure performance and trend reports.
 
 [[creating-a-time-profile]]
 ==== Creating a Time Profile


### PR DESCRIPTION
Updates throughout this chapter include:

* Physical infrastructure section to default filters for BZ#1739693
* Removed an outdated (unneccessary) screenshot for start page
* Edited some capitalization and missing words
* Added a note about navigating to My Settings at the beginning of this chapter for better usability