### PR TITLE
Bug BZ1647742 - Removed item numbers

### DIFF
--- a/common/configuration-db.adoc
+++ b/common/configuration-db.adoc
@@ -12,17 +12,17 @@ ifdef::ssh[]
 endif::ssh[]
 . Enter the `appliance_console` command. The {product-title} appliance summary screen displays.
 . Press *Enter* to manually configure settings.
-. Select *5) Configure Database* from the menu.
+. Select *Configure Database* from the menu.
 . You are prompted to create or fetch an encryption key.
-* If this is the first {product-title} appliance, choose *1) Create key*.
-* If this is not the first {product-title} appliance, choose *2) Fetch key from remote machine* to fetch the key from the first appliance. For worker and multi-region setups, use this option to copy key from another appliance.
+* If this is the first {product-title} appliance, choose *Create key*.
+* If this is not the first {product-title} appliance, choose *Fetch key from remote machine* to fetch the key from the first appliance. For worker and multi-region setups, use this option to copy key from another appliance.
 +
 [NOTE]
 ====
 All {product-title_short} appliances in a multi-region deployment must use the same key.
 ====
 +
-. Choose *1) Create Internal Database* for the database location.
+. Choose *Create Internal Database* for the database location.
 . Choose a disk for the database. This can be either a disk you attached previously, or a partition on the current disk.
 +
 [IMPORTANT]

--- a/common/configuration.adoc
+++ b/common/configuration.adoc
@@ -68,17 +68,17 @@ ifdef::ssh[]
 endif::ssh[]
 . Enter the `appliance_console` command. The {product-title} appliance summary screen displays.
 . Press *Enter* to manually configure settings.
-. Select *5) Configure Database* from the menu.
+. Select *Configure Database* from the menu.
 . You are prompted to create or fetch a security key.
-* If this is the first {product-title} appliance, choose *1) Create key*.
-* If this is not the first {product-title} appliance, choose *2) Fetch key from remote machine* to fetch the key from the first appliance.
+* If this is the first {product-title} appliance, choose *Create key*.
+* If this is not the first {product-title} appliance, choose *Fetch key from remote machine* to fetch the key from the first appliance.
 +
 [NOTE]
 ====
 All {product-title_short} appliances in a multi-region deployment must use the same key.
 ====
 +
-. Choose *2) Create Region in External Database* for the database location.
+. Choose *Create Region in External Database* for the database location.
 . Enter the database hostname or IP address when prompted.
 . Enter the database name or leave blank for the default (`vmdb_production`).
 . Enter the database username or leave blank for the default (`root`).
@@ -101,7 +101,7 @@ ifdef::ssh[]
 endif::ssh[]
 . Enter the `appliance_console` command. The {product-title} appliance summary screen displays.
 . Press *Enter* to manually configure settings.
-. Select *5) Configure Database* from the menu.
+. Select *Configure Database* from the menu.
 . You are prompted to create or fetch a security key. Since this is not the first {product-title} appliance, choose *2) Fetch key from remote machine*. For worker and multi-region setups, use this option to copy the security key from another appliance.
 +
 [NOTE]
@@ -109,7 +109,7 @@ endif::ssh[]
 All {product-title_short} appliances in a multi-region deployment must use the same key.
 ====
 +
-. Choose *3) Join Region in External Database* for the database location.
+. Choose *Join Region in External Database* for the database location.
 . Enter the database hostname or IP address when prompted.
 . Enter the port number or leave blank for the default (`5432`).
 . Enter the database name or leave blank for the default (`vmdb_production`).


### PR DESCRIPTION
For Bug BZ1647742 -- removed menu item numbers. Number in manual was incorrect because number had changed. We are removing the numbers since numbers will continue to change going forward as new items are added. Now the manual just instructs the user to select the action, rather than a numbered action.