### PR TITLE
Remove Master SAML Processing URL

### DIFF
--- a/auth/saml.adoc
+++ b/auth/saml.adoc
@@ -108,7 +108,12 @@ The Client definition for the appliance can then be updated with the following:
 | Valid Redirect URIs                             | https://<miq-appliance>/saml2/paosResponse
 |                                                 | https://<miq-appliance>/saml2/postResponse
 | Base URL                                        | https://<miq-appliance>/
-| Under: *Fine Grain SAML Endpoint Configuration* |
+|=========================================================================================
+
+[options="header"]
+|=========================================================================================
+| *Fine Grain SAML Endpoint Configuration*        |
+| *Setting*                                       | *Value*
 | Assertion Consumer Service POST Binding URL     | https://<miq-appliance>/saml2/postResponse
 | Assertion Consumer Service Redirect Binding URL | https://<miq-appliance>/saml2/postResponse
 | Logout Service Redirect Binding URL             | https://<miq-appliance>/saml2/logout

--- a/auth/saml.adoc
+++ b/auth/saml.adoc
@@ -108,7 +108,7 @@ The Client definition for the appliance can then be updated with the following:
 | Valid Redirect URIs                             | https://<miq-appliance>/saml2/paosResponse
 |                                                 | https://<miq-appliance>/saml2/postResponse
 | Base URL                                        | https://<miq-appliance>/
-| Master SAML Processing URL                      | https://<miq-appliance>/saml2
+| Under: *Fine Grain SAML Endpoint Configuration* |
 | Assertion Consumer Service POST Binding URL     | https://<miq-appliance>/saml2/postResponse
 | Assertion Consumer Service Redirect Binding URL | https://<miq-appliance>/saml2/postResponse
 | Logout Service Redirect Binding URL             | https://<miq-appliance>/saml2/logout


### PR DESCRIPTION
Remove the line instructing users to configure the "Master SAML Processing URL". Sometimes it works to have this line configured and sometimes it does not but it always works if this line is omitted. So removing it from the configuration instructions ensure a working environment.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1767404

This is really a duplicate of [BZ 1519310](https://bugzilla.redhat.com/show_bug.cgi?id=1519310) but I decided just to leave this BZ open to track the needed changes to the documentation on manageiq.org

