### PR TITLE
Map httpd-auth PAM service to Group Policy rule in sssd.conf

### DIFF
--- a/auth/active_directory.adoc
+++ b/auth/active_directory.adoc
@@ -92,6 +92,7 @@ Update the */etc/sssd/sssd.conf* file as follows:
     use_fully_qualified_names = True
     fallback_homedir = /home/%d/%u
     access_provider = ad
+=>  ad_gpo_map_permit = +httpd-auth
 =>  ldap_user_extra_attrs = mail, givenname, sn, displayname, domainname
    
 =>  [sssd]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1798664

Update the doc to include adding the following line to the sssd.conf file:
  ad_gpo_map_permit = +httpd-auth

The PAM service 'httpd-auth' must be mapped to a Group Policy rule. It is recommended
to use the ad_gpo_map_* family of options to map PAM service 'httpd-auth' to a Group
Policy rule.
