### PR TITLE
Update retire_services.adoc multiple service retirement call

### DIFF
--- a/api/examples/retire_services.adoc
+++ b/api/examples/retire_services.adoc
@@ -11,7 +11,7 @@ POST /api/services
 [source,json]
 ----
 {
-  "action" : "retire",
+  "action" : "request_retire",
   "resources" : [
       { "href" : "http://localhost:3000/api/services/100" },
       { "href" : "http://localhost:3000/api/services/101", "date" : "11/01/2015", "warn" : "4" },


### PR DESCRIPTION
`retire` is the old call and will break, `request_retire` is what should be here
see https://github.com/ManageIQ/manageiq_docs/pull/1347 and http://talk.manageiq.org/t/retirement-as-a-request/4797