### PR TITLE
Removing closed known issues, updating RHEL pre-migration playbook section

### DIFF
--- a/doc-Infrastructure_Migration_Solution_Guide/cfme/modules/proc_Creating_a_rhel_premigration_playbook.adoc
+++ b/doc-Infrastructure_Migration_Solution_Guide/cfme/modules/proc_Creating_a_rhel_premigration_playbook.adoc
@@ -5,32 +5,35 @@
 [id="Creating_a_rhel_premigration_playbook_{context}"]
 = Creating a `RHEL premigration` playbook for RHEL/Linux source virtual machines
 
-If you are migrating virtual machines running RHEL or other Linux operating system, you can create a `RHEL premigration` playbook to ensure that the IP addresses are accessible after migration. The `RHEL premigration` playbook calls the Ansible `ims.rhel_premigration` role.
+If you are migrating virtual machines running RHEL or other Linux operating systems, you must create a `RHEL premigration` playbook to call the Ansible `ims.rhel_premigration` role.
 
-To install the role with Ansible Galaxy, see link:https://galaxy.ansible.com/fdupont_redhat/ims_rhel_pre_migration[ims_rhel_pre_migration]. This role is not included in the IMS installation.
+The `ims.rhel_premigration` role ensures that the virtual machine IP addresses are accessible after migration.
 
-ifdef::rhv_1-1_vddk,rhv_1-2_vddk,rhv_1-3_vddk[]
-The `ims.rhel_premigration` role performs the following tasks on the migrating VMware virtual machines:
+.Prerequisites
 
-* Preserves the static IP addresses
-* Installs the Red Hat Virtualization guest agent, which reports the IP addresses and installed applications to the Manager
-endif::[]
-ifdef::osp_1-1_vddk,osp_1-2_vddk,osp_1-3_vddk[]
-The `ims.rhel_premigration` role preserves the static IP addresses of the migrating VMware virtual machines.
-endif::[]
+* The `rhel-<version>-server-rpms` repository must be enabled for the source virtual machines. If you have disabled it, you can re-enable it in the RHEL premigration playbook.
 
-[NOTE]
-====
-The `ims.rhel_premigration` role assumes that either the `rhel-6-server-rpms` or the `rhel-7-server-rpms` repository is enabled in the source virtual machine when it installs `qemu-guest-agent`.
+.Procedure
 
-If you have disabled the repository, you must re-enable it in the RHEL premigration playbook.
-====
-
-.`RHEL premigration` playbook example
+. link:https://galaxy.ansible.com/fdupont_redhat/ims_rhel_pre_migration[Install the `ims.rhel_premigration` role] with Ansible Galaxy.
+. Create a `RHEL premigration` playbook according to the following example:
++
 [source,yml]
 ----
 ---
-- hosts: all
+- hosts: to_be_migrated
+  vars:
+    rhsm_config: <1>
+      server_hostname: "server.example.com"
+      server_username: "admin"
+      server_password: "secret" <2>
+      org_id: "my_organization"
+    rhsm_repositories:
+      - "rhel-<version>-server-rpms"
   roles:
     - role: ims.rhel_pre_migration
 ----
+<1> Specify the configuration parameters for your environment.
+<2> Passwords and other sensitive information should be encrypted with Ansible vault.
+
+You will add this playbook when you create your migration plan.

--- a/doc-Infrastructure_Migration_Solution_Guide/cfme/modules/proc_Creating_a_rhel_premigration_playbook.adoc
+++ b/doc-Infrastructure_Migration_Solution_Guide/cfme/modules/proc_Creating_a_rhel_premigration_playbook.adoc
@@ -3,9 +3,9 @@
 // IMS_1.1/master.adoc
 // IMS_1.2/master.adoc
 [id="Creating_a_rhel_premigration_playbook_{context}"]
-= Creating a `RHEL premigration` playbook for RHEL/Linux source virtual machines
+= Creating a `RHEL premigration` playbook for RHEL/Linux virtual machines
 
-If you are migrating virtual machines running RHEL or other Linux operating systems, you must create a `RHEL premigration` playbook to call the Ansible `ims.rhel_premigration` role.
+If you are migrating virtual machines running RHEL or other Linux operating systems, you must create and run a `RHEL premigration` playbook to call the Ansible `ims.rhel_premigration` role.
 
 The `ims.rhel_premigration` role ensures that the virtual machine IP addresses are accessible after migration.
 

--- a/doc-Infrastructure_Migration_Solution_Guide/cfme/modules/ref_Known_issues.adoc
+++ b/doc-Infrastructure_Migration_Solution_Guide/cfme/modules/ref_Known_issues.adoc
@@ -7,27 +7,11 @@
 The following are known issues:
 
 ifdef::rhv_1-1_vddk,osp_1-1_vddk[]
-* BZ#1698761: link:https://bugzilla.redhat.com/show_bug.cgi?id=1698761["Maximum concurrent migrations per conversion host" interface control does not work]
-
-* BZ#716283: link:https://bugzilla.redhat.com/show_bug.cgi?id=1716283[Migrating virtual machines are not distributed correctly among the conversion hosts]
-
 * BZ#1709211: link:https://bugzilla.redhat.com/show_bug.cgi?id=1709211#c2[ESXi 5.5 requires VDDK version 6.7.0]
-
-* CloudForms CFME 5.10.4 does not support migration. Use CFME 5.10.3.
 endif::[]
-
-* BZ#1678385: link:https://bugzilla.redhat.com/show_bug.cgi?id=1678385[Virtual machine with name containing spaces ('rhel 7') fails to migrate]
-
-* BZ#1699343: link:https://bugzilla.redhat.com/show_bug.cgi?id=1699343[Migration plan CSV import validation does not work if file contains empty/archived/orphan/invalid VM name]
 
 * BZ#1726939: link:https://bugzilla.redhat.com/show_bug.cgi?id=1726939[Run the preflight check of migration task before waiting for a conversion host]. Currently, the preflight check that monitors the migration is performed after a conversion host is assigned to the task. As a result, the total volume of the Datastores reported in *Migration Plans In Progress* reflects the total volume of the virtual machines that are currently migrating, not the total volume of the migration plan. When all the virtual machines have started to migrate, the correct value of the total volume is displayed.
 
-ifdef::rhv_1-1_vddk,rhv_1-2_vddk,rhv_1-3_vddk[]
-* BZ#1666799: link:https://bugzilla.redhat.com/show_bug.cgi?id=1666799[Canceling a migration does not stop creating virtual machines on RHV]. If you cancel a migration, you must delete migrated virtual machines and disks in the Administration Portal.
+* BZ#1791802: link:https://bugzilla.redhat.com/show_bug.cgi?id=1791802[virt-v2v does not install qemu-ga on EL8 guest]. Currently, when migrating a Red Hat Enterprise Linux 8 virtual machine, the Qemu guest agent is not installed. The impact is that the IP address of the virtual machine will not be reported in RHV inventory, and the post-migration playbook inventory will contain only "localhost". This may lead to unexpected behavior of the playbook. We recommend to not associate a post-migration playbook to Red Hat Enterprise Linux 8 virtual machines in a migration plan.
 
-* BZ#1669176: link:https://bugzilla.redhat.com/show_bug.cgi?id=1669176[Refreshing the hosts causes the network(s) and datastore to disappear from infrastructure mappings]
-endif::[]
-
-ifdef::osp_1-1_vddk,osp_1-2_vddk,osp_1-3_vddk[]
-* BZ#1668049: link:https://bugzilla.redhat.com/show_bug.cgi?id=1668049[Instance is not created after disk conversion]
-endif::[]
+ this will be solved in virt-v2v-1.40.2-21.module+el8.2.0+5851+8d6a931b.x86_64.rpm, planned to be released with RHEL AV 8.2.0, i.e. in May.

--- a/doc-Infrastructure_Migration_Solution_Guide/cfme/modules/ref_Known_issues.adoc
+++ b/doc-Infrastructure_Migration_Solution_Guide/cfme/modules/ref_Known_issues.adoc
@@ -10,8 +10,18 @@ ifdef::rhv_1-1_vddk,osp_1-1_vddk[]
 * BZ#1709211: link:https://bugzilla.redhat.com/show_bug.cgi?id=1709211#c2[ESXi 5.5 requires VDDK version 6.7.0]
 endif::[]
 
+ifdef::rhv_1-1_vddk,rhv_1-2_vddk,rhv_1-3_vddk[]
+* BZ#1791802: link:https://bugzilla.redhat.com/show_bug.cgi?id=1791802[virt-v2v does not install QEMU-GA on RHEL 8 virtual machine]. In the current release, the QEMU guest agent is not installed on a migrated RHEL 8 virtual machine. As a result, the virtual machine's IP address is not reported in the Red Hat Virtualization inventory. A post-migration playbook inventory will contain only `localhost`. Therefore, you should not associate a post-migration playbook with RHEL 8 virtual machines in a migration plan. This bug will be resolved by RHEL-AV 8.2.0, to be released in May 2020.
+
+// Possible post-migration task for RHEL 8:
+// ----
+// ---
+// - name: Install qemu-guest-agent package
+//   yum:
+//     name: qemu-guest-agent
+//     state: present
+//   when: ansible_distribution == "RedHat" and ansible_distribution_major_version >= "8"
+// ----
+endif::[]
+
 * BZ#1726939: link:https://bugzilla.redhat.com/show_bug.cgi?id=1726939[Run the preflight check of migration task before waiting for a conversion host]. Currently, the preflight check that monitors the migration is performed after a conversion host is assigned to the task. As a result, the total volume of the Datastores reported in *Migration Plans In Progress* reflects the total volume of the virtual machines that are currently migrating, not the total volume of the migration plan. When all the virtual machines have started to migrate, the correct value of the total volume is displayed.
-
-* BZ#1791802: link:https://bugzilla.redhat.com/show_bug.cgi?id=1791802[virt-v2v does not install qemu-ga on EL8 guest]. Currently, when migrating a Red Hat Enterprise Linux 8 virtual machine, the Qemu guest agent is not installed. The impact is that the IP address of the virtual machine will not be reported in RHV inventory, and the post-migration playbook inventory will contain only "localhost". This may lead to unexpected behavior of the playbook. We recommend to not associate a post-migration playbook to Red Hat Enterprise Linux 8 virtual machines in a migration plan.
-
- this will be solved in virt-v2v-1.40.2-21.module+el8.2.0+5851+8d6a931b.x86_64.rpm, planned to be released with RHEL AV 8.2.0, i.e. in May.

--- a/doc-Infrastructure_Migration_Solution_Guide/cfme/modules/ref_Known_issues.adoc
+++ b/doc-Infrastructure_Migration_Solution_Guide/cfme/modules/ref_Known_issues.adoc
@@ -10,18 +10,4 @@ ifdef::rhv_1-1_vddk,osp_1-1_vddk[]
 * BZ#1709211: link:https://bugzilla.redhat.com/show_bug.cgi?id=1709211#c2[ESXi 5.5 requires VDDK version 6.7.0]
 endif::[]
 
-ifdef::rhv_1-1_vddk,rhv_1-2_vddk,rhv_1-3_vddk[]
-* BZ#1791802: link:https://bugzilla.redhat.com/show_bug.cgi?id=1791802[virt-v2v does not install QEMU-GA on RHEL 8 virtual machine]. In the current release, the QEMU guest agent is not installed on a migrated RHEL 8 virtual machine. As a result, the virtual machine's IP address is not reported in the Red Hat Virtualization inventory. A post-migration playbook inventory will contain only `localhost`. Therefore, you should not associate a post-migration playbook with RHEL 8 virtual machines in a migration plan. This bug will be resolved by RHEL-AV 8.2.0, to be released in May 2020.
-
-// Possible post-migration task for RHEL 8:
-// ----
-// ---
-// - name: Install qemu-guest-agent package
-//   yum:
-//     name: qemu-guest-agent
-//     state: present
-//   when: ansible_distribution == "RedHat" and ansible_distribution_major_version >= "8"
-// ----
-endif::[]
-
 * BZ#1726939: link:https://bugzilla.redhat.com/show_bug.cgi?id=1726939[Run the preflight check of migration task before waiting for a conversion host]. Currently, the preflight check that monitors the migration is performed after a conversion host is assigned to the task. As a result, the total volume of the Datastores reported in *Migration Plans In Progress* reflects the total volume of the virtual machines that are currently migrating, not the total volume of the migration plan. When all the virtual machines have started to migrate, the correct value of the total volume is displayed.


### PR DESCRIPTION
Updated "Known Issues" by removing closed issues.
Because of [BZ#1791802](https://bugzilla.redhat.com/show_bug.cgi?id=1791802), qemu-ga installation for RHEL 8 has been added to Ansible RHEL pre-migration role. Updated RHEL pre-migration playbook section.

[Doc preview](http://file.tlv.redhat.com/~apinnick/IMS_update_known_issues_IMS_1.2/)