### PR TITLE
ims-vddk-versions-update

### DIFF
--- a/doc-Infrastructure_Migration_Solution_Guide/cfme/IMS_1.1/master.adoc
+++ b/doc-Infrastructure_Migration_Solution_Guide/cfme/IMS_1.1/master.adoc
@@ -79,11 +79,10 @@ include::modules/proc_Installing_configuring_cf.adoc[leveloffset=+3]
 
 You can configure the Red Hat Virtualization conversion hosts with Ansible playbooks to use the VMware Virtual Disk Development Kit (VDDK). VDDK converts the VMware disks.
 
-You then authenticate the conversion hosts in the CloudForms user interface.
-
-include::modules/proc_Downloading_vddk.adoc[leveloffset=+3]
-include::modules/proc_Configuring_conversion_hosts_ansible.adoc[leveloffset=+3]
-include::modules/proc_Authenticating_rhv_conversion_hosts.adoc[leveloffset=+3]
+include::modules/ref_note_vddk.adoc[leveloffset=+1]
+include::modules/proc_Downloading_vddk.adoc[leveloffset=+4]
+include::modules/proc_Configuring_conversion_hosts_ansible.adoc[leveloffset=+4]
+include::modules/proc_Authenticating_rhv_conversion_hosts.adoc[leveloffset=+4]
 
 [id='Migrating_virtual_machines_{context}']
 == Migrating the virtual machines
@@ -235,9 +234,10 @@ You can create the Red Hat OpenStack Platform conversion hosts.
 
 You then configure the conversion hosts with Ansible playbooks to use the VMware Virtual Disk Development Kit (VDDK). VDDK converts the VMware disks.
 
-include::modules/proc_Creating_osp_conversion_hosts.adoc[leveloffset=+3]
-include::modules/proc_Downloading_vddk.adoc[leveloffset=+3]
-include::modules/proc_Configuring_conversion_hosts_ansible.adoc[leveloffset=+3]
+include::modules/proc_Creating_osp_conversion_hosts.adoc[leveloffset=+4]
+include::modules/proc_Downloading_vddk.adoc[leveloffset=+4]
+include::modules/ref_note_vddk.adoc[leveloffset=+1]
+include::modules/proc_Configuring_conversion_hosts_ansible.adoc[leveloffset=+4]
 
 [id='Migrating_virtual_machines_{context}']
 == Migrating the virtual machines

--- a/doc-Infrastructure_Migration_Solution_Guide/cfme/IMS_1.2/master.adoc
+++ b/doc-Infrastructure_Migration_Solution_Guide/cfme/IMS_1.2/master.adoc
@@ -83,8 +83,10 @@ include::modules/proc_Installing_configuring_multi-cf.adoc[leveloffset=+3]
 
 You can configure the Red Hat Virtualization conversion hosts in the CloudForms user interface to use the VMware Virtual Disk Development Kit (VDDK). VDDK converts the VMware disks.
 
-include::modules/proc_Downloading_vddk.adoc[leveloffset=+3]
-include::modules/proc_Configuring_conversion_hosts_cloudforms.adoc[leveloffset=+3]
+include::modules/ref_note_vddk.adoc[leveloffset=+1]
+include::modules/proc_Downloading_vddk.adoc[leveloffset=+4]
+include::modules/proc_Configuring_conversion_hosts_cloudforms.adoc[leveloffset=+4]
+include::modules/proc_Verifying_conversion_hosts_in_browser.adoc[leveloffset=+4]
 
 [id='Migrating_virtual_machines_{context}']
 == Migrating the virtual machines
@@ -233,11 +235,11 @@ include::modules/proc_Installing_configuring_multi-cf.adoc[leveloffset=+3]
 
 You can create the Red Hat OpenStack Platform conversion hosts with the conversion appliance.
 
-You then configure the conversion hosts in the CloudForms user interface to use the VMware Virtual Disk Development Kit (VDDK). VDDK converts the VMware disks.
-
-include::modules/proc_Creating_osp_conversion_hosts.adoc[leveloffset=+3]
-include::modules/proc_Downloading_vddk.adoc[leveloffset=+3]
-include::modules/proc_Configuring_conversion_hosts_cloudforms.adoc[leveloffset=+3]
+include::modules/proc_Creating_osp_conversion_hosts.adoc[leveloffset=+4]
+include::modules/proc_Downloading_vddk.adoc[leveloffset=+4]
+include::modules/ref_note_vddk.adoc[leveloffset=+1]
+include::modules/proc_Configuring_conversion_hosts_cloudforms.adoc[leveloffset=+4]
+include::modules/proc_Verifying_conversion_hosts_in_browser.adoc[leveloffset=+4]
 
 [id='Migrating_virtual_machines_{context}']
 == Migrating the virtual machines

--- a/doc-Infrastructure_Migration_Solution_Guide/cfme/IMS_1.3/master.adoc
+++ b/doc-Infrastructure_Migration_Solution_Guide/cfme/IMS_1.3/master.adoc
@@ -90,10 +90,12 @@ You can create the Red Hat Virtualization conversion hosts with the Universal Co
 
 You then configure the conversion hosts in the CloudForms user interface to use the VMware Virtual Disk Development Kit (VDDK). VDDK converts the VMware disks.
 
-include::modules/proc_Downloading_conversion_host_image.adoc[leveloffset=+3]
-include::modules/proc_Creating_rhv_conversion_host_with_uci.adoc[leveloffset=+3]
-include::modules/proc_Downloading_vddk.adoc[leveloffset=+3]
-include::modules/proc_Configuring_conversion_hosts_cloudforms.adoc[leveloffset=+3]
+include::modules/proc_Downloading_conversion_host_image.adoc[leveloffset=+4]
+include::modules/proc_Creating_rhv_conversion_host_with_uci.adoc[leveloffset=+4]
+include::modules/proc_Downloading_vddk.adoc[leveloffset=+4]
+include::modules/ref_note_vddk.adoc[leveloffset=+1]
+include::modules/proc_Configuring_conversion_hosts_cloudforms.adoc[leveloffset=+4]
+include::modules/proc_Verifying_conversion_hosts_in_browser.adoc[leveloffset=+4]
 
 [id='Migrating_virtual_machines_{context}']
 == Migrating the virtual machines
@@ -248,10 +250,12 @@ You can create the Red Hat OpenStack Platform conversion hosts with the Universa
 
 You then configure the conversion hosts in the CloudForms user interface to use the VMware Virtual Disk Development Kit (VDDK). VDDK converts the VMware disks.
 
-include::modules/proc_Downloading_conversion_host_image.adoc[leveloffset=+3]
-include::modules/proc_Creating_osp_conversion_hosts.adoc[leveloffset=+3]
-include::modules/proc_Downloading_vddk.adoc[leveloffset=+3]
-include::modules/proc_Configuring_conversion_hosts_cloudforms.adoc[leveloffset=+3]
+include::modules/proc_Downloading_conversion_host_image.adoc[leveloffset=+4]
+include::modules/proc_Creating_osp_conversion_hosts.adoc[leveloffset=+4]
+include::modules/proc_Downloading_vddk.adoc[leveloffset=+4]
+include::modules/ref_note_vddk.adoc[leveloffset=+1]
+include::modules/proc_Configuring_conversion_hosts_cloudforms.adoc[leveloffset=+4]
+include::modules/proc_Verifying_conversion_hosts_in_browser.adoc[leveloffset=+4]
 
 [id='Migrating_virtual_machines_{context}']
 == Migrating the virtual machines

--- a/doc-Infrastructure_Migration_Solution_Guide/cfme/modules/proc_Downloading_vddk.adoc
+++ b/doc-Infrastructure_Migration_Solution_Guide/cfme/modules/proc_Downloading_vddk.adoc
@@ -12,15 +12,7 @@ You can download the VMware Virtual Disk Development Kit (VDDK).
 
 . In a browser, navigate to link:https://code.vmware.com/sdks[VMware {code} SDKs].
 . Click *Virtual Disk Development Kit (VDDK)*.
-. Select the VDDK release for your VMware version.
-ifdef::rhv_1-1_vddk,osp_1-1_vddk[]
-+
-[NOTE]
-====
-VMware 5.5 requires VDDK 6.7 for migration.
-====
-endif::[]
-
+. Select the VDDK release specified for your VMware version.
 . Click *Download* and log in with your VMware account credentials.
 ifdef::rhv_1-1_vddk,osp_1-1_vddk[]
 . Save the VDDK archive file in an HTTP-accessible location and record its path.

--- a/doc-Infrastructure_Migration_Solution_Guide/cfme/modules/proc_Downloading_vddk.adoc
+++ b/doc-Infrastructure_Migration_Solution_Guide/cfme/modules/proc_Downloading_vddk.adoc
@@ -8,26 +8,20 @@
 
 You can download the VMware Virtual Disk Development Kit (VDDK).
 
-.Prerequisites
-
-* VMware account credentials
-
 .Procedure
 
-. In a browser, navigate to link:https://www.vmware.com/support/pubs/[VMware Documentation].
-. Log in with your VMware account credentials.
-. Click *VMware SDK & API Product Documentation* -> *VMware Virtual Disk Development Kit (VDDK)*.
-. Select the latest VDDK release.
+. In a browser, navigate to link:https://code.vmware.com/sdks[VMware {code} SDKs].
+. Click *Virtual Disk Development Kit (VDDK)*.
+. Select the VDDK release for your VMware version.
 ifdef::rhv_1-1_vddk,osp_1-1_vddk[]
 +
 [NOTE]
 ====
-If you are using VMware 5.5, you must download VDDK version 6.7.
+VMware 5.5 requires VDDK 6.7 for migration.
 ====
 endif::[]
 
-. Click *Download SDKs* to download the `tar.gz` VDDK archive file.
-
+. Click *Download* and log in with your VMware account credentials.
 ifdef::rhv_1-1_vddk,osp_1-1_vddk[]
 . Save the VDDK archive file in an HTTP-accessible location and record its path.
 endif::[]

--- a/doc-Infrastructure_Migration_Solution_Guide/cfme/modules/ref_Software_compatibility.adoc
+++ b/doc-Infrastructure_Migration_Solution_Guide/cfme/modules/ref_Software_compatibility.adoc
@@ -16,6 +16,14 @@ endif::[]
 ifdef::rhv_1-2_vddk,osp_1-2_vddk,rhv_1-3_vddk,osp_1-3_vddk[]
 |VMware |6.0 or later
 endif::[]
+ifdef::rhv_1-1_vddk,osp_1-1_vddk[]
+|VMware Virtual Disk Development Kit (VDDK) a|6.5, for VMware 5.5
+
+If your VMware version is 6.0 or later, use the corresponding VDDK version.
+endif::[]
+ifdef::rhv_1-2_vddk,osp_1-2_vddk,rhv_1-3_vddk,osp_1-3_vddk[]
+|VMware Virtual Disk Development Kit (VDDK) |Use the VDDK version that corresponds to your VMware version.
+endif::[]
 ifdef::rhv_1-1_vddk[]
 |Red Hat Virtualization |4.2
 endif::[]

--- a/doc-Infrastructure_Migration_Solution_Guide/cfme/modules/ref_Software_compatibility.adoc
+++ b/doc-Infrastructure_Migration_Solution_Guide/cfme/modules/ref_Software_compatibility.adoc
@@ -17,12 +17,11 @@ ifdef::rhv_1-2_vddk,osp_1-2_vddk,rhv_1-3_vddk,osp_1-3_vddk[]
 |VMware |6.0 or later
 endif::[]
 ifdef::rhv_1-1_vddk,osp_1-1_vddk[]
-|VMware Virtual Disk Development Kit (VDDK) a|6.5, for VMware 5.5
-
-If your VMware version is 6.0 or later, use the corresponding VDDK version.
+|VMware Virtual Disk Development Kit (VDDK) a|6.5
 endif::[]
 ifdef::rhv_1-2_vddk,osp_1-2_vddk,rhv_1-3_vddk,osp_1-3_vddk[]
-|VMware Virtual Disk Development Kit (VDDK) |Use the VDDK version that corresponds to your VMware version.
+|VMware Virtual Disk Development Kit (VDDK) a|* VMware 6.0 and 6.5: VDDK 6.5
+* VMware 6.7: VDDK 6.7
 endif::[]
 ifdef::rhv_1-1_vddk[]
 |Red Hat Virtualization |4.2

--- a/doc-Infrastructure_Migration_Solution_Guide/cfme/modules/ref_note_vddk.adoc
+++ b/doc-Infrastructure_Migration_Solution_Guide/cfme/modules/ref_note_vddk.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// IMS_1.1/master.adoc
+// IMS_1.2/master.adoc
+// IMS_1.3/master.adoc
+[NOTE]
+====
+See xref:Software_compatibility_{context}[] for the required VDDK version.
+====


### PR DESCRIPTION
Document which versions of VDDK need to be downloaded for specific versions of VMware.
Doc previews:

http://file.tlv.redhat.com/~apinnick/ims-vddk-for-vmware-6-5_IMS_1.1/#Downloading_vddk_for_rhv_1-1_vddk
http://file.tlv.redhat.com/~apinnick/ims-vddk-for-vmware-6-5_IMS_1.2/#Downloading_vddk_for_rhv_1-2_vddk
http://file.tlv.redhat.com/~apinnick/ims-vddk-for-vmware-6-5_IMS_1.3/#Downloading_vddk_for_rhv_1-3_vddk