### PR TITLE
IMS: configuring existing target environments

### DIFF
--- a/doc-Infrastructure_Migration_Solution_Guide/cfme/IMS_1.1/master.adoc
+++ b/doc-Infrastructure_Migration_Solution_Guide/cfme/IMS_1.1/master.adoc
@@ -70,9 +70,10 @@ include::modules/proc_Configuring_vmware_hypervisor_for_more_than_10_concurrent_
 [id='Preparing_the_rhv_environment_{context}']
 === Installing and configuring the Red Hat environment
 
-You can install and configure Red Hat Virtualization and CloudForms.
+You can install and configure Red Hat Virtualization and CloudForms for migration.
 
 include::modules/proc_Installing_configuring_rhv.adoc[leveloffset=+3]
+include::modules/proc_Configuring_existing_rh_environment.adoc[leveloffset=+3]
 include::modules/proc_Installing_configuring_cf.adoc[leveloffset=+3]
 
 === Configuring the Red Hat Virtualization conversion hosts
@@ -223,9 +224,10 @@ include::modules/proc_Configuring_vmware_hypervisor_for_more_than_10_concurrent_
 
 === Installing and configuring the Red Hat environment
 
-You can install and configure Red Hat OpenStack Platform and CloudForms.
+You can install and configure Red Hat OpenStack Platform and CloudForms for migration.
 
 include::modules/proc_Installing_osp.adoc[leveloffset=+3]
+include::modules/proc_Configuring_existing_rh_environment.adoc[leveloffset=+3]
 include::modules/proc_Installing_configuring_cf.adoc[leveloffset=+3]
 
 [id='Deploying_conversion_hosts-{context}']
@@ -260,8 +262,9 @@ Check your migration for the following conditions, which have prerequisites:
 include::modules/proc_Creating_a_csv_file_to_add_virtual_machines_to_the_migration_plan.adoc[leveloffset=+3]
 include::modules/proc_Adding_ansible_playbooks_to_cloudforms.adoc[leveloffset=+3]
 include::modules/proc_Creating_a_rhel_premigration_playbook.adoc[leveloffset=+3]
+
 include::modules/proc_Creating_an_infrastructure_mapping.adoc[leveloffset=+2]
-include::modules/proc_Creating_a_migration_plan_in_cloudforms.adoc[leveloffset=+1]
+include::modules/proc_Creating_a_migration_plan_in_cloudforms.adoc[leveloffset=+2]
 
 include::modules/proc_Changing_the_maximum_number_of_concurrent_migrations.adoc[leveloffset=+2]
 

--- a/doc-Infrastructure_Migration_Solution_Guide/cfme/IMS_1.2/master.adoc
+++ b/doc-Infrastructure_Migration_Solution_Guide/cfme/IMS_1.2/master.adoc
@@ -70,11 +70,10 @@ include::modules/proc_Configuring_vmware_hypervisor_for_more_than_10_concurrent_
 [id='Preparing_the_rhv_environment_{context}']
 === Installing and configuring the Red Hat environment
 
-You can install and configure Red Hat Virtualization for migration.
-
-You can install and configure one or more CloudForms appliances.
+You can install and configure Red Hat Virtualization and one or more CloudForms appliances for migration.
 
 include::modules/proc_Installing_configuring_rhv.adoc[leveloffset=+3]
+include::modules/proc_Configuring_existing_rh_environment.adoc[leveloffset=+3]
 include::modules/proc_Installing_configuring_cf.adoc[leveloffset=+3]
 include::modules/proc_Installing_configuring_multi-cf.adoc[leveloffset=+3]
 
@@ -222,11 +221,10 @@ include::modules/proc_Configuring_vmware_hypervisor_for_more_than_10_concurrent_
 
 === Installing and configuring the Red Hat environment
 
-You can install and configure Red Hat OpenStack Platform for migration.
-
-You can install and configure one or more CloudForms appliances.
+You can install and configure Red Hat OpenStack Platform and one or more CloudForms appliances for migration.
 
 include::modules/proc_Installing_osp.adoc[leveloffset=+3]
+include::modules/proc_Configuring_existing_rh_environment.adoc[leveloffset=+3]
 include::modules/proc_Installing_configuring_cf.adoc[leveloffset=+3]
 include::modules/proc_Installing_configuring_multi-cf.adoc[leveloffset=+3]
 

--- a/doc-Infrastructure_Migration_Solution_Guide/cfme/IMS_1.3/master.adoc
+++ b/doc-Infrastructure_Migration_Solution_Guide/cfme/IMS_1.3/master.adoc
@@ -94,10 +94,6 @@ include::modules/proc_Creating_rhv_conversion_host_with_uci.adoc[leveloffset=+3]
 include::modules/proc_Downloading_vddk.adoc[leveloffset=+3]
 include::modules/ref_note_vddk.adoc[leveloffset=+1]
 include::modules/proc_Configuring_conversion_hosts_cloudforms.adoc[leveloffset=+3]
-<<<<<<< HEAD
-include::modules/proc_Verifying_conversion_hosts_in_browser.adoc[leveloffset=+3]
-=======
->>>>>>> Added section for configuring existing Red Hat target environments to 1.1, 1.2, 1.3
 
 [id='Migrating_virtual_machines_{context}']
 == Migrating the virtual machines
@@ -256,10 +252,6 @@ include::modules/proc_Creating_osp_conversion_hosts.adoc[leveloffset=+3]
 include::modules/proc_Downloading_vddk.adoc[leveloffset=+3]
 include::modules/ref_note_vddk.adoc[leveloffset=+1]
 include::modules/proc_Configuring_conversion_hosts_cloudforms.adoc[leveloffset=+3]
-<<<<<<< HEAD
-include::modules/proc_Verifying_conversion_hosts_in_browser.adoc[leveloffset=+3]
-=======
->>>>>>> Added section for configuring existing Red Hat target environments to 1.1, 1.2, 1.3
 
 [id='Migrating_virtual_machines_{context}']
 == Migrating the virtual machines

--- a/doc-Infrastructure_Migration_Solution_Guide/cfme/IMS_1.3/master.adoc
+++ b/doc-Infrastructure_Migration_Solution_Guide/cfme/IMS_1.3/master.adoc
@@ -72,13 +72,12 @@ include::modules/proc_Configuring_vmware_hypervisor_for_more_than_10_concurrent_
 [id='Preparing_the_rhv_environment_{context}']
 === Installing and configuring the Red Hat environment
 
-You can install and configure Red Hat Virtualization for migration.
-
-You can install and configure one or more CloudForms appliances.
+You can install and configure Red Hat Virtualization and one or more CloudForms appliances for migration.
 
 Optionally, you can xref:Updating_vmware_host_ip_api_{context}[update a VMware host's IP address with the CloudForms API] to use a faster network for migration.
 
 include::modules/proc_Installing_configuring_rhv.adoc[leveloffset=+3]
+include::modules/proc_Configuring_existing_rh_environment.adoc[leveloffset=+3]
 include::modules/proc_Installing_configuring_cf.adoc[leveloffset=+3]
 include::modules/proc_Installing_configuring_multi-cf.adoc[leveloffset=+3]
 include::modules/proc_Setting_vmware_host_ip_address.adoc[leveloffset=+3]
@@ -95,7 +94,10 @@ include::modules/proc_Creating_rhv_conversion_host_with_uci.adoc[leveloffset=+3]
 include::modules/proc_Downloading_vddk.adoc[leveloffset=+3]
 include::modules/ref_note_vddk.adoc[leveloffset=+1]
 include::modules/proc_Configuring_conversion_hosts_cloudforms.adoc[leveloffset=+3]
+<<<<<<< HEAD
 include::modules/proc_Verifying_conversion_hosts_in_browser.adoc[leveloffset=+3]
+=======
+>>>>>>> Added section for configuring existing Red Hat target environments to 1.1, 1.2, 1.3
 
 [id='Migrating_virtual_machines_{context}']
 == Migrating the virtual machines
@@ -232,13 +234,12 @@ include::modules/proc_Configuring_vmware_hypervisor_for_more_than_10_concurrent_
 
 === Installing and configuring the Red Hat environment
 
-You can install and configure Red Hat OpenStack Platform for migration.
-
-You can install and configure one or more CloudForms appliances.
+You can install and configure Red Hat OpenStack Platform and one or more CloudForms appliances for migration.
 
 Optionally, you can xref:Updating_vmware_host_ip_api_{context}[update a VMware host's IP address with the CloudForms API] to use a faster network for migration.
 
 include::modules/proc_Installing_osp.adoc[leveloffset=+3]
+include::modules/proc_Configuring_existing_rh_environment.adoc[leveloffset=+3]
 include::modules/proc_Installing_configuring_cf.adoc[leveloffset=+3]
 include::modules/proc_Installing_configuring_multi-cf.adoc[leveloffset=+3]
 include::modules/proc_Setting_vmware_host_ip_address.adoc[leveloffset=+3]
@@ -255,7 +256,10 @@ include::modules/proc_Creating_osp_conversion_hosts.adoc[leveloffset=+3]
 include::modules/proc_Downloading_vddk.adoc[leveloffset=+3]
 include::modules/ref_note_vddk.adoc[leveloffset=+1]
 include::modules/proc_Configuring_conversion_hosts_cloudforms.adoc[leveloffset=+3]
+<<<<<<< HEAD
 include::modules/proc_Verifying_conversion_hosts_in_browser.adoc[leveloffset=+3]
+=======
+>>>>>>> Added section for configuring existing Red Hat target environments to 1.1, 1.2, 1.3
 
 [id='Migrating_virtual_machines_{context}']
 == Migrating the virtual machines

--- a/doc-Infrastructure_Migration_Solution_Guide/cfme/modules/proc_Configuring_existing_rh_environment.adoc
+++ b/doc-Infrastructure_Migration_Solution_Guide/cfme/modules/proc_Configuring_existing_rh_environment.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+// IMS_1.1/master.adoc
+// IMS_1.2/master.adoc
+// IMS_1.3/master.adoc
+[id='Configuring_existing_environment_{context}']
+ifdef::rhv_1-1_vddk,rhv_1-2_vddk,rhv_1-3_vddk[]
+= Configuring an existing Red Hat Virtualization environment
+
+If you are migrating to an existing Red Hat Virtualization (RHV) environment, the following guidelines may apply:
+endif::[]
+
+ifdef::rhv_1-1_vddk,rhv_1-2_vddk[]
+* Upgrade RHV to the latest release.
+* Check each conversion host for valid subscriptions and repositories:
++
+----
+# subscription-manager list --consumed
+# yum repolist
+----
+
+* Check each conversion host for existing SSH private keys in `/var/lib/vdsm/.ssh/id_rsa`.
++
+Delete the keys manually before configuring the host. Conversion host configuration does not overwrite existing keys.
+
+* If the MAC address pool range overlaps the VMware MAC address range, ensure that the MAC addresses of the migrating virtual machines do not duplicate those of existing virtual machines.
++
+If you do not create a MAC address pool, the migrated virtual machines will not have MAC addresses in the same range as virtual machines created in Red Hat Virtualization.
+endif::[]
+
+ifdef::rhv_1-3_vddk[]
+* Upgrade RHV to the latest release.
+endif::[]
+
+ifdef::osp_1-1_vddk,osp_1-2_vddk,osp_1-3_vddk[]
+= Configuring an existing Red Hat OpenStack Platform environment
+
+If you are migrating to an existing Red Hat OpenStack Platform (RHOSP) environment, the following guidelines may apply:
+
+* When you add the RHOSP provider to CloudForms, wait for CloudForms to update its event history before attempting to use the provider.
++
+You can check the link:https://access.redhat.com/documentation/en-us/red_hat_cloudforms/5.0/html-single/managing_providers/index#viewing_the_management_system_timeline[cloud provider timeline] to verify that all events have been processed.
+endif::[]


### PR DESCRIPTION
Added section for configuring existing Red Hat target environments to IMS 1.1, 1.2, 1.3
https://issues.redhat.com/browse/MIGENG-529
Doc previews:
http://file.tlv.redhat.com/~apinnick/ims-configuring-existing-target-environments_IMS_1.1/#Configuring_existing_environment_rhv_1-1_vddk
http://file.tlv.redhat.com/~apinnick/ims-configuring-existing-target-environments_IMS_1.1/#Configuring_existing_environment_osp_1-1_vddk
http://file.tlv.redhat.com/~apinnick/ims-configuring-existing-target-environments_IMS_1.2/#Configuring_existing_environment_rhv_1-2_vddk
http://file.tlv.redhat.com/~apinnick/ims-configuring-existing-target-environments_IMS_1.2/#Configuring_existing_environment_osp_1-2_vddk
http://file.tlv.redhat.com/~apinnick/ims-configuring-existing-target-environments_IMS_1.3/#Configuring_existing_environment_rhv_1-3_vddk
http://file.tlv.redhat.com/~apinnick/ims-configuring-existing-target-environments_IMS_1.3/#Configuring_existing_environment_osp_1-3_vddk
