### PR TITLE
Remove pause/resume documentation for Container Providers

### DIFF
--- a/doc-Managing_Providers/topics/Containers_Providers.adoc
+++ b/doc-Managing_Providers/topics/Containers_Providers.adoc
@@ -83,10 +83,6 @@ include::Removing_Containers_Providers.adoc[]
 
 
 :leveloffset: 2
-include::Pause_Resume_Containers_Providers.adoc[]
-
-
-:leveloffset: 2
 include::Editing_a_Containers_Provider.adoc[]
 
 


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq_docs/issues/1368

it seems to have been removed in https://github.com/ManageIQ/manageiq/pull/19915 and https://github.com/ManageIQ/manageiq-api/pull/740