### PR TITLE
update retirement calls for consistency

### DIFF
--- a/api/reference/service_custom_actions.adoc
+++ b/api/reference/service_custom_actions.adoc
@@ -335,7 +335,7 @@ As an example, here's a service without custom buttons:
       "href": "http://localhost:3000/api/services/91"
     },
     {
-      "name": "retire",
+      "name": "request_retire",
       "method": "post",
       "href": "http://localhost:3000/api/services/91"
     },
@@ -381,7 +381,7 @@ Here is an example of a service with custom buttons:
       "href": "http://localhost:3000/api/services/92"
     },
     {
-      "name": "retire",
+      "name": "request_retire",
       "method": "post",
       "href": "http://localhost:3000/api/services/92"
     },


### PR DESCRIPTION
since we've been using the request call since I it feels weird to only have the old call in this one place. we have to keep the old call for backwards compatibility on the automate side but anything in docs should be using the new call so we don't confuse anyone