### PR TITLE
Fixed section about Network Manager for Active Directory.

### DIFF
--- a/auth/active_directory.adoc
+++ b/auth/active_directory.adoc
@@ -19,14 +19,15 @@ In these examples, the AD Domain shown will be EXAMPLE.COM
 [[enabling-nm]]
 == Enabling Network Manager
 
-This is an *optional* step for allowing realm to discover the Active Directory domain. If not enabled, one
+By default, the appliance is configured with Network Manager enabled. Having Network Manager enabled allows
+the *realm* command to discover the available Active Directory domains that can be joined. If not enabled, one
 can still join an AD domain if known by the domain name.
+
+If the appliance has Network Manager disabled, it can be enabled as follows:
 
 ----
 # systemctl enable NetworkManager
 # systemctl start NetworkManager
-# sed -i '/^NM_CONTROLLED=.*/d;$aNM_CONTROLLED=yes' /etc/sysconfig/network-scripts/ifcfg-eth0
-# systemctl restart network
 ----
 
 [[discovering-ad-domain]]


### PR DESCRIPTION
- Fixed section about Network Manager for Active Directory. It is now enabled by default on the appliance, and the instructions needed to enable it have changed since CentOS 6.

Fixes: https://github.com/ManageIQ/manageiq_docs/issues/10