### PR TITLE
Adding the queue_chargeback_report action for the services api doc page.

### DIFF
--- a/api/reference/services.adoc
+++ b/api/reference/services.adoc
@@ -427,6 +427,7 @@ Additional Service actions include:
 
 * link:#service-add-remove-resources[Adding and Removing Resources from Services]
 * link:#service-add-provider-vms[Adding Provider VMs to Services]
+* link:#service-queue-chargeback-report[Requesting a Chargeback Report for a Service]
 
 Other than service creates and edits, service actions return the action response as
 in the following example:
@@ -638,6 +639,40 @@ POST /api/services/:id
 }
 ----
 
+[[service-queue-chargeback-report]]
+==== Requesting a Chargeback Report for a Service
+
+This action will request a chargeback report for the service.
+
+----
+POST /api/services/:id
+----
+
+[source,json]
+----
+{
+  "action" : "queue_chargeback_report"
+}
+----
+
+The queue_chargeback_report action will return an action response which includes the task reference as shown here:
+
+[source,json]
+----
+{
+  "success": true,
+  "message": "Queued chargeback report generation for Service id:1 name:'test_service1'",
+  "task_id": "39",
+  "task_href": "http://localhost:3000/api/tasks/39"
+}
+----
+
+The task_href can be queried and upon completion of the task, the chargeback report for the service can be
+queried as follows:
+
+----
+GET /api/services/:id?attributes=chargeback_report
+----
 
 [[service-retiring-now]]
 ==== Service Retiring (now)


### PR DESCRIPTION
- Adding the queue_chargeback_report action for the services api doc page. was missing the "queue_chargeback_report" action for services.

/cc @lpichler please review 🙏Thanks.


Fixes: https://github.com/ManageIQ/manageiq_docs/issues/197