### PR TITLE
Preferring the "request_retire" action over the older "retire".

### DIFF
--- a/api/examples/custom_action_service.adoc
+++ b/api/examples/custom_action_service.adoc
@@ -222,7 +222,7 @@ GET /api/services/110?attributes=custom_actions
       "href": "http://localhost:3000/api/services/110"
     },
     {
-      "name": "retire",
+      "name": "request_retire",
       "method": "post",
       "href": "http://localhost:3000/api/services/110"
     },


### PR DESCRIPTION

Should be exposing the newer "request_retire" action.
