### PR TITLE
Fix example for POST /api/rates

### DIFF
--- a/api/reference/chargebacks_rates.adoc
+++ b/api/reference/chargebacks_rates.adoc
@@ -164,6 +164,7 @@ POST /api/rates
 {
   "per_time" : "daily",
   "chargeback_rate_id" : "1",
+  "chargeable_field_id" : "1",
   "description": "My CPU allocation rate",
   "group" : "cpu",
   "per_unit" : "megahertz",
@@ -178,6 +179,7 @@ POST /api/rates
 {
   "results": [
     {
+      "href": "http://localhost:3000/api/rates/16",
       "id": "16",
       "enabled": true,
       "description": "My CPU allocation rate",
@@ -187,6 +189,7 @@ POST /api/rates
       "per_unit": "megahertz",
       "friendly_rate": "",
       "chargeback_rate_id": "1",
+      "chargeable_field_id": "1",
       "created_on": "2016-08-16T08:27:22Z",
       "updated_on": "2016-08-16T08:27:22Z"
     }


### PR DESCRIPTION
Fix example for POST /api/rates
- was missing the now required chargeable_field_id.

/cc @lpichler please review 🙏

Fixes: https://github.com/ManageIQ/manageiq_docs/issues/238
