### PR TITLE
Add example dialog id to custom button create

### DIFF
--- a/api/reference/custom_buttons.adoc
+++ b/api/reference/custom_buttons.adoc
@@ -209,7 +209,8 @@ POST /api/custom_buttons
   },
   "resource_action"  : {
     "ae_namespace"   : "SYSTEM",
-    "ae_class"       : "PROCESS"
+    "ae_class"       : "PROCESS",
+    "dialog_id"      : "1"
   },
   "visibility"       : {
     "roles"          : ["_ALL_"]


### PR DESCRIPTION
Otherwise I don't think we have an example showing that this is via the resource action. It is relevant all the way back to five ten and would be cool if it were in those docs. 