### PR TITLE
Updated Version History Doc for the API

### DIFF
--- a/api/overview/versioning.adoc
+++ b/api/overview/versioning.adoc
@@ -2,10 +2,70 @@
 [[manageiq-rest-api-version-history]]
 == Version History
 
-[cols="1,1,1,5",options="header"]
+
+[cols="2,2,7",options="header"]
 |=======================================================================
-|API Version |Entry Points |Published |Description
-|*3.0.0* |/api, /api/v3.0.0 |January 2018 |
+|API Version & Entrypoints| Published Release |Description
+|*4.2.0*
+
+/api, /api/v4.2.0
+|June 2020
+
+_Jansa_|
+Added support for Configured Systems,
+Creating Providers via DDF,
+Requesting compliance checks,
+Added pagination, ordering and filtering of report result sets,
+Added support for Tag filtering by expression in Groups
+|*4.1.0*
+
+/api, /api/v4.1.0
+|September 2019
+
+_Ivanchuk_|
+Added support for CRUD of Firmware Registries,
+Added CD-ROMs and Disks subcollection for VMs,
+Provisioning of Physical Servers,
+API authentication via OpenID-Connect,
+Automation Domains,
+Pluggable API Support,
+Pxe Servers,
+Widget Content Generation,
+Policy Profiles,
+Added Compliance subcollection to VMs
+|*4.0.0*
+
+/api, /api/v4.0.0
+|January 2019
+
+_Hammer_|
+Added support for Conversion Hosts,
+Updates of Transformation Mappings,
+Cloud Volume Types,
+Bulk Tagging of Users,
+Configuration Scripts,
+Accessing Event Streams of Physical Resources,
+Physical Storage, Racks, and Chassis,
+Physical Switches and related Power actions,
+Support Queued Retirement for VMs and Services,
+Password updates for Providers,
+Tagging of Availability Zones, Cloud Networks, Cloud Subnets, Flavors, Network Routers, and Security Groups,
+CRUD for Templates,
+Lans and Network Subcollection for Hosts and Providers,
+Folders subcollection on providers (#338)
+Pause and Resume actions to Providers,
+Chargeback Reports for Services,
+Settings support for Servers and Regions,
+Switches, Container Volumes, Container Templates,
+Container Images, Container Groups and Cloud Object Store Containers,
+Added Transformation Mapping Support,
+Support Enabling and Disabling Conversion Hosts
+|*3.0.0*
+
+/api, /api/v3.0.0
+|January 2018
+
+_Gaprindashvili_|
 Settings Management,
 CRUD of Custom Button Sets,
 CRUD of Custom Buttons,
@@ -50,8 +110,14 @@ Support multi-manager Provider refreshes,
 Refreshing Authentications,
 Refreshing Configuration Script Sources,
 Enable edits for Automation and Provision Requests,
-Assigning and Unassining Policies from Policy Profiles 
-|*2.4.0* |/api, /api/v2.4.0 |June 2017 | CRUD on actions,
+Assigning and Unassigning Policies from Policy Profiles
+|*2.4.0*
+
+/api, /api/v2.4.0 |
+June 2017
+
+_fine_|
+CRUD on actions,
 Creating and accessing alert actions of alert resources,
 CRUD on Alert Definitions,
 Querying Alerts,
@@ -78,7 +144,13 @@ Editing Vms,
 Creating, Querying, Reverting and Deleting Snapshots of Vms,
 Bulk assignment of Tags on Vms,
 Creating, Querying and Deleting Snapshots of Instances
-|*2.3.0* |/api, /api/v2.3.0 |December 2016 |Automate Collection,
+|*2.3.0*
+
+/api, /api/v2.3.0
+|December 2016
+
+_Euwe_|
+Automate Collection,
 Automate Domains Collection, Automate Domain refresh_from_source,
 Collection OPTIONS and metadata,
 Service Power Operations,
@@ -96,7 +168,13 @@ Queries of Virtual Templates,
 Cloud Networks subcollection for Providers,
 Service Create action,
 CRUD on Orchestration Templates
-|*2.2.0* |/api, /api/v2.2.0 |June 2016 |CRUD on Groups,
+|*2.2.0*
+
+/api, /api/v2.2.0
+|June 2016
+
+_Darga_|
+CRUD on Groups,
 CRUD on Users,
 Updating a Host password,
 Service Reconfigure action,
@@ -109,7 +187,13 @@ Querying enhancements to support case insensitive sorting,
 CRUD on Tenant quotas,
 Exposing read-only subset of Settings,
 Shopping Carts
-|*2.1.0* |/api, /api/v2.1.0 |November 2015 |CRUD on Tenants,
+|*2.1.0*
+
+/api, /api/v2.1.0
+|November 2015
+
+_Capablanca_|
+CRUD on Tenants,
 CRUD on Categories and Tags,
 CRUD on User Roles,
 CRUD on Chargeback Rates,
@@ -124,7 +208,13 @@ User group authorization,
 Additional Primary Collections: Features, Roles, Tenants,
 Service dialogs, Provision dialogs,
 Reports, Chargebacks, Rates, Categories, Tags
-|*2.0.0* |/api, /api/v2.0.0 |May 2015 |Parity with SOAP API,
+|*2.0.0*
+
+/api, /api/v2.0.0
+|May 2015
+
+_Botvinnik_|
+Parity with SOAP API,
 Support for Providers CRUD & Refresh action,
 VM Control Management,
 VM Custom Attributes,
@@ -133,9 +223,21 @@ Tag Management,
 Policy and Policy Profile Management,
 Improved Action Result responses,
 Expanded Primary collections
-|*1.1* |/api/v1.1 |October 2014 |CVE-2014-7814 Fix,
+|*1.1*
+
+/api, /api/v1.1
+|October 2014
+
+_Anand_|
+CVE-2014-7814 Fix,
 sqlfilter replaced with new filter[] parameter
-|*1.0* |/api/v1.0 |August 2014 |Foundation,
+|*1.0*
+
+/api, /api/v1.0
+|August 2014
+
+|
+Foundation,
 Collections, Resources and Subcollections,
 Querying, Filtering, Paging, and Sorting,
 Tagging,


### PR DESCRIPTION
Updated Version History Doc for the API.
- Improved Format
- Adding Upstream release names
- Was missing information since Hammer