### PR TITLE
DDF BZ change chronyd

### DIFF
--- a/doc-High_Availability_Guide/topics/Installation.adoc
+++ b/doc-High_Availability_Guide/topics/Installation.adoc
@@ -17,7 +17,7 @@ See the installation guide for your host platform (such as https://access.redhat
 ====
 endif::cfme[]
 +
-. Configure time synchronization on the appliance by editing `/etc/chronyd.conf` with valid NTP server information.
+. Configure time synchronization on the appliance by editing `/etc/chrony.conf` with valid NTP server information.
 . From your host environment, open the appliance and configure the network:
 .. Log in to the appliance and run the `appliance_console` command to access the appliance console menu.
 .. Configure networking as desired by selecting the *Set DHCP Network Configuration* or *Set Static Network Configuration* option.
@@ -68,7 +68,7 @@ Region metadata is required to configure the primary database-only appliance as 
 ====
 
 . Deploy a {product-title_short} appliance. There is no requirement for an extra disk on this appliance.
-. Configure time synchronization on the appliance by editing `/etc/chronyd.conf` with valid NTP server information.
+. Configure time synchronization on the appliance by editing `/etc/chrony.conf` with valid NTP server information.
 . From your host environment, open the appliance and configure the network:
 .. Log in to the appliance and run the `appliance_console` command to access the appliance console menu.
 .. Configure networking as desired by selecting the *Set DHCP Network Configuration* or *Set Static Network Configuration* option.
@@ -148,7 +148,7 @@ The standby database-only appliance is a copy of the primary database-only appli
 Follow these steps to create a new standby appliance, or to add another standby appliance to the cluster.
 
 . Deploy a {product-title_short} appliance with an extra (and unpartitioned) disk for the database that is the same size as the primary database-only appliance, as it will contain the same data. For recommendations on disk space, see https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/html/deployment_planning_guide/introduction#database-requirements[Database Requirements] in the _Deployment Planning Guide_.
-. Configure time synchronization on the appliance by editing `/etc/chronyd.conf` with valid NTP server information.
+. Configure time synchronization on the appliance by editing `/etc/chrony.conf` with valid NTP server information.
 . From your host environment, open the appliance and configure the network:
 .. Log in to the appliance and run the `appliance_console` command to access the appliance console menu.
 .. Configure networking as desired by selecting the *Set DHCP Network Configuration* or *Set Static Network Configuration* option.
@@ -201,7 +201,7 @@ Verify the configuration on the appliance console details screen for the standby
 Install a second virtual machine with a {product-title_short} appliance and any additional appliances in the region using the following steps:
 
 . Deploy a {product-title_short} appliance. There is no requirement for an extra disk on this appliance.
-. Configure time synchronization on the appliance by editing `/etc/chronyd.conf` with valid NTP server information.
+. Configure time synchronization on the appliance by editing `/etc/chrony.conf` with valid NTP server information.
 . From your host environment, open the appliance and configure the network:
 .. Log in to the appliance and run the `appliance_console` command to access the appliance console menu.
 .. Configure networking as desired by selecting the *Set DHCP Network Configuration* or *Set Static Network Configuration* option.


### PR DESCRIPTION
For DDF BZ: changed incorrect path from /etc/chronyd.conf to /etc/chrony.conf in Chapter 2, Installing the Appliances. (Occurs in several places in the chapter -- see step 2 of installation.)

This is for BZ1758291