### PR TITLE
Fix documented Automate Domain for ServiceNow

### DIFF
--- a/integration_with_servicenow/_topics/overview.md
+++ b/integration_with_servicenow/_topics/overview.md
@@ -11,7 +11,7 @@ The following new namespace and class delivers support for the
 management of **ServiceNow Configuration Management Database** (CMDB)
 records using **ServiceNow’s RESTful** web service.
 
-    /RedHat/Integration/ServiceNow/CMDB
+    /ManageIQ/Integration/ServiceNow/CMDB
 
 You can manage records in the **CMDB\_CI\_SERVER** table, including
 `create`, `update`, and/or `delete`. The following methods are included:


### PR DESCRIPTION
This should be `/ManageIQ/...` in upstream, so fixing that.