### PR TITLE
Fix menu link for Automation Management Providers

### DIFF
--- a/_data/site_menu.yml
+++ b/_data/site_menu.yml
@@ -85,7 +85,7 @@ using:
             desc: "Managing Red Hat Satellite 6 Providers"
 
         - title: Automation Management Providers
-          path: "/docs/reference/latest/managing_providers/index.html#automation-management-provider"
+          path: "/docs/reference/latest/managing_providers/index.html#automation-management-providers"
           desc: "Management tool to simplify automation operators for resources"
 
         - title: Cloud Providers


### PR DESCRIPTION
It looks like 5fefff63b968359fe7e3050bc9311fcbf3218f40 (https://github.com/ManageIQ/manageiq-documentation/pull/1806/commits/5fefff63b968359fe7e3050bc9311fcbf3218f40#diff-46686079121737af3636a6d1c95d842fc981118049ec6ece21ce578576eebd50R92) was had a typo in the link which causes the link to not bring the use to the right section

Clicking on the link in the menu brings you to the top of the Managing Providers page
![image](https://github.com/user-attachments/assets/fd52cdf9-9640-4468-9f5e-f3b976c9eb49)

Adding an `s` to the URL
![image](https://github.com/user-attachments/assets/ffff81d5-3c99-4533-9ce4-6d5f9e2f08fd)

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
