### PR TITLE
Document AAP Deprecated Catalog Item

### DIFF
--- a/managing_providers/_topics/automation_management_providers.md
+++ b/managing_providers/_topics/automation_management_providers.md
@@ -249,6 +249,8 @@ Then, create an Ansible Automation Platform service catalog item:
 6. Click **Configuration**, then ![Add a New Catalog Item](../images/1862.png) (**Add a New Catalog Item**) to create a new catalog item with the following details, at minimum:
 
    - For **Catalog Item type**, select **Ansible Automation Platform**.
+     **NOTE** If you have existing **Ansible Automation Platform** Catalog Item it might show up as **Ansible Automation Platform (deprecated)** type.
+     These Catalog Item types cannot be used with Embedded Workflows and are being phased out.  It is recommended that you create a new **Catalog Item** with the new type.
 
    - Enter a **Name** for the service catalog item.
 


### PR DESCRIPTION
Add a note about deprecated AWX/AAP automate-based catalog item types.  We should include this in the upgrade docs for the next release but I don't think there is anywhere to start those yet.

Note I don't see anything about AWX here.  I'll tackle adding AWX to the docs here separately.

Ref:
https://github.com/ManageIQ/manageiq-providers-awx/pull/55
https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/332
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
