### PR TITLE
Add example of timeout to Services add_provider_vms

### DIFF
--- a/api/reference/services.md
+++ b/api/reference/services.md
@@ -558,7 +558,9 @@ services:
 
 For cases where VMs are created externally, i.e. via Ansible Playbooks,
 this action allows the system to identify the VMs created and link those
-VMs back to the service.
+VMs back to the service.  This accepts an optional "timeout" parameter which
+dictates in seconds how long the task should wait for the VM to be added
+to the database.  If not specified the default is 300 seconds.
 
 ``` data
 POST /api/services/:id
@@ -573,7 +575,8 @@ POST /api/services/:id
       "provider_vm_id1",
       "provider_vm_id2",
       ...
-    ]
+    ],
+    "timeout" : 600
   }
 }
 ```


### PR DESCRIPTION
Add an API example showing the usage of "timeout" when adding provider VMs to a service over the API.

Depends on:
- [x] https://github.com/ManageIQ/manageiq-api/pull/1315
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
