### PR TITLE
Add SCVMM back to capabilities_matrix

### DIFF
--- a/capabilities_matrix/_topics/infrastructure_providers.md
+++ b/capabilities_matrix/_topics/infrastructure_providers.md
@@ -2,67 +2,67 @@
 
  The following tables outline the capabilities of {{ site.data.product.title_short }} that are known to work for various virtual infrastructure providers.
 
-| Discovery                                                    | vSphere | oVirt / RHV | OpenStack undercloud    | IBM Power HMC | KubeVirt / OSV | Nutanix | Proxmox |
-| ------------------------------------------------------------ | ------- | ----------- | ----------------------- | ------------- | -------------- | ------- | ------- |
-| Compute Inventory                                            | ✅      | ✅          | ✅ (Nodes and Services) | ✅            | ✅             | ✅     | ✅       |
-| Network Inventory                                            | ✅      | ✅ (OVN)    | ❌                      | ✅            | ❌             | ❌     | ✅       |
-| Storage Inventory                                            | ✅      | ❌          | ❌                      | ✅            | ✅             | ✅     | ✅       |
-| Events                                                       | ✅      | ✅          | ✅                      | ✅            | ❌             | ❌     | ❌       |
-| Metrics                                                      | ✅      | ✅          | ✅                      | ✅            | ✅             | ❌     | ❌       |
-| Forensic Analysis (SmartState)                               | ✅      | ✅          | ✅ (Nodes)              | ❌            | ❌             | ❌     | ❌       |
+| Discovery                                                    | vSphere | oVirt / RHV | SCVMM | OpenStack undercloud    | IBM Power HMC | KubeVirt / OSV | Nutanix | Proxmox |
+| ------------------------------------------------------------ | ------- | ----------- | ----- | ----------------------- | ------------- | -------------- | ------- | ------- |
+| Compute Inventory                                            | ✅      | ✅          | ✅    | ✅ (Nodes and Services) | ✅            | ✅             | ✅     | ✅       |
+| Network Inventory                                            | ✅      | ✅ (OVN)    | ✅    | ❌                      | ✅            | ❌             | ❌     | ✅       |
+| Storage Inventory                                            | ✅      | ❌          | ✅    | ❌                      | ✅            | ✅             | ✅     | ✅       |
+| Events                                                       | ✅      | ✅          | ❌    | ✅                      | ✅            | ❌             | ❌     | ❌       |
+| Metrics                                                      | ✅      | ✅          | ❌    | ✅                      | ✅            | ✅             | ❌     | ❌       |
+| Forensic Analysis (SmartState)                               | ✅      | ✅          | ❌    | ✅ (Nodes)              | ❌            | ❌             | ❌     | ❌       |
 
-| General Features                                             | vSphere | oVirt / RHV | OpenStack undercloud | IBM Power HMC | KubeVirt / OSV | Nutanix | Proxmox |
-| ------------------------------------------------------------ | ------- | ----------- | -------------------- | ------------- | -------------- | ------- | ------- |
-| Relationship Discovery                                       | ✅      | ✅          | ✅                   | ✅            | ✅             | ✅      | ✅      |
-| Drift Comparison                                             | ✅      | ✅          | ✅ (Nodes)           | ❌            | ❌             | ❌      | ❌      |
-| VM Genealogy                                                 | ✅      | ✅          | ✅                   | ❌            | ✅             | ❌      | ❌      |
-| Capacity & Utilization                                       | ✅      | ✅          | ✅                   | ✅            | ❌             | ❌      | ❌      |
-| VM Event Timelines                                           | ✅      | ✅          | ❌                   | ✅            | ✅             | ❌      | ❌      |
-| Infrastructure Event Timelines                               | ❌      | ❌          | ✅                   | ❌            | ❌             | ❌      | ❌      |
-| Reporting                                                    | ✅      | ✅          | ✅                   | ✅            | ✅             | ✅      | ❌      |
-| Right Sizing                                                 | ✅      | ✅          | ❌                   | ✅            | ❌             | ❌      | ❌      |
-| Chargeback by Allocation                                     | ✅      | ✅          | ❌                   | ❌            | ❌             | ❌      | ❌      |
-| Chargeback by Usage                                          | ✅      | ✅          | ❌                   | ❌            | ❌             | ❌      | ❌      |
-| Automation Work Flows                                        | ✅      | ✅          | ❌                   | ❌            | ❌             | ❌      | ❌      |
-| Tag Mapping from Provider                                    | ❌      | ❌          | ❌                   | ❌            | ❌             | ❌      | ❌      |
-| Tag Mapping to Provider                                      | ❌      | ❌          | ❌                   | ❌            | ❌             | ❌      | ❌      |
-| VM Compliance Enforcement                                    | ✅      | ✅          | ❌                   | ❌            | ❌             | ❌      | ❌      |
-| VM Policy Enforcement                                        | ✅      | ✅          | ❌                   | ❌            | ❌             | ❌      | ❌      |
-| Alerts - Real Time                                           | ✅      | ❌          | ❌                   | ❌            | ❌             | ❌      | ❌      |
-| Alerts - VM Value Changed                                    | ✅      | ✅          | ❌                   | ❌            | ❌             | ❌      | ❌      |
-| Alerts - VM Reconfigured                                     | ✅      | ✅          | ❌                   | ❌            | ❌             | ❌      | ❌      |
-| Integrate with Service Catalogs                              | ✅      | ✅          | ❌                   | ✅            | ✅             | ❌      | ❌      |
+| General Features                                             | vSphere | oVirt / RHV | SCVMM | OpenStack undercloud | IBM Power HMC | KubeVirt / OSV | Nutanix | Proxmox |
+| ------------------------------------------------------------ | ------- | ----------- | ----- | -------------------- | ------------- | -------------- | ------- | ------- |
+| Relationship Discovery                                       | ✅      | ✅          | ✅    | ✅                   | ✅            | ✅             | ✅      | ✅      |
+| Drift Comparison                                             | ✅      | ✅          | ✅    | ✅ (Nodes)           | ❌            | ❌             | ❌      | ❌      |
+| VM Genealogy                                                 | ✅      | ✅          | ✅    | ✅                   | ❌            | ✅             | ❌      | ❌      |
+| Capacity & Utilization                                       | ✅      | ✅          | ❌    | ✅                   | ✅            | ❌             | ❌      | ❌      |
+| VM Event Timelines                                           | ✅      | ✅          | ❌    | ❌                   | ✅            | ✅             | ❌      | ❌      |
+| Infrastructure Event Timelines                               | ❌      | ❌          | ❌    | ✅                   | ❌            | ❌             | ❌      | ❌      |
+| Reporting                                                    | ✅      | ✅          | ✅    | ✅                   | ✅            | ✅             | ✅      | ❌      |
+| Right Sizing                                                 | ✅      | ✅          | ❌    | ❌                   | ✅            | ❌             | ❌      | ❌      |
+| Chargeback by Allocation                                     | ✅      | ✅          | ✅    | ❌                   | ❌            | ❌             | ❌      | ❌      |
+| Chargeback by Usage                                          | ✅      | ✅          | ❌    | ❌                   | ❌            | ❌             | ❌      | ❌      |
+| Automation Work Flows                                        | ✅      | ✅          | ✅    | ❌                   | ❌            | ❌             | ❌      | ❌      |
+| Tag Mapping from Provider                                    | ❌      | ❌          | ❌    | ❌                   | ❌            | ❌             | ❌      | ❌      |
+| Tag Mapping to Provider                                      | ❌      | ❌          | ❌    | ❌                   | ❌            | ❌             | ❌      | ❌      |
+| VM Compliance Enforcement                                    | ✅      | ✅          | ✅    | ❌                   | ❌            | ❌             | ❌      | ❌      |
+| VM Policy Enforcement                                        | ✅      | ✅          | ✅    | ❌                   | ❌            | ❌             | ❌      | ❌      |
+| Alerts - Real Time                                           | ✅      | ❌          | ❌    | ❌                   | ❌            | ❌             | ❌      | ❌      |
+| Alerts - VM Value Changed                                    | ✅      | ✅          | ❌    | ❌                   | ❌            | ❌             | ❌      | ❌      |
+| Alerts - VM Reconfigured                                     | ✅      | ✅          | ❌    | ❌                   | ❌            | ❌             | ❌      | ❌      |
+| Integrate with Service Catalogs                              | ✅      | ✅          | ✅    | ❌                   | ✅            | ✅             | ❌      | ❌      |
 
-| Operations                                                   | vSphere | oVirt / RHV | OpenStack undercloud    | IBM Power HMC | KubeVirt / OSV | Nutanix | Proxmox |
-| ------------------------------------------------------------ | ------- | ----------- | ----------------------- | --------------| -------------- | ------- | ------- |
-| VM Remote Console Access (see section below)                 | ✅      | ✅          | ❌                      | ❌            | ✅             | ❌      | ❌      |
-| VM Power Operations                                          | ✅      | ✅          | ❌                      | ✅            | ✅             | ✅      | ✅      |
-| VM Provisioning                                              |         |             |                         |               |                |         |
-|   &nbsp;&nbsp;&bull; using PXE                               | ✅      | ✅          | ❌                      | ❌            | ❌             | ❌      | ❌      |
-|   &nbsp;&nbsp;&bull; using ISO                               | ❌      | ✅          | ❌                      | ❌            | ❌             | ❌      | ❌      |
-|   &nbsp;&nbsp;&bull; from Template to VM                     | ✅      | ✅          | ❌                      | ✅            | ✅             | ❌      | ❌      |
-|   &nbsp;&nbsp;&bull; from VM to Template                     | ✅      | ✅          | ❌                      | ✅            | ❌             | ❌      | ❌      |
-|   &nbsp;&nbsp;&bull; Clone from VM to VM                     | ✅      | ❌          | ❌                      | ❌            | ❌             | ❌      | ❌      |
-|   &nbsp;&nbsp;&bull; Sysprep Windows Templates               | ✅      | ✅          | ❌                      | ❌            | ❌             | ❌      | ❌      |
-|   &nbsp;&nbsp;&bull; Cloud-init                              | ❌      | ✅          | ❌                      | ❌            | ❌             | ❌      | ❌      |
-| VM Retirement                                                | ✅      | ✅          | ❌                      | ✅            | ✅             | ✅      | ✅      |
-| VM Reconfiguration                                           | ✅      | ✅          | ❌                      | ❌            | ✅ *           | ❌      | ❌      |
-|   &nbsp;&nbsp;&bull; Disk Addition                           | ✅      | ✅          | ❌                      | ❌            | ❌             | ❌      | ❌      |
-|   &nbsp;&nbsp;&bull; Network Interface Add/Remove            | ✅      | ✅          | ❌                      | ❌            | ❌             | ❌      | ❌      |
-| VM Snapshot Creation and Removal                             | ✅      | ✅          | ❌                      | ❌            | ❌             | ❌      | ❌      |
-| Host Power Operations                                        | ✅      | ❌          | ✅                      | ✅            | ❌             | ❌      | ❌      |
-| Node Operations                                              |         |             |                         |               | ❌             | ❌      | ❌      |
-|   &nbsp;&nbsp;&bull; Add/Remove Node                         | ❌      | ❌          | ✅                      | ❌            | ❌             | ❌      | ❌      |
-|   &nbsp;&nbsp;&bull; Scale Down Node                         | ❌      | ❌          | ✅ (Compute nodes only) | ❌            | ❌             | ❌      | ❌      |
-|   &nbsp;&nbsp;&bull; Scale Up Nodes                          | ❌      | ❌          | ✅ (Compute nodes only) | ❌            | ❌             | ❌      | ❌      |
-|   &nbsp;&nbsp;&bull; Nodes Policy Enforcement                | ❌      | ❌          | ✅                      | ❌            | ❌             | ❌      | ❌      |
-|   &nbsp;&nbsp;&bull; Nodes Evacuate                          | ❌      | ❌          | ✅                      | ❌            | ❌             | ❌      | ❌      |
-| Create Cloud Network                                         | ❌      | ✅          | ❌                      | ❌            | ❌             | ❌      | ❌      |
-| Delete Cloud Network                                         | ❌      | ✅          | ❌                      | ❌            | ❌             | ❌      | ❌      |
-| Create Cloud Subnet                                          | ❌      | ✅          | ❌                      | ❌            | ❌             | ❌      | ❌      |
-| Delete Cloud Subnet                                          | ❌      | ✅          | ❌                      | ❌            | ❌             | ❌      | ❌      |
-| Create Network Router                                        | ❌      | ✅          | ❌                      | ❌            | ❌             | ❌      | ❌      |
-| Delete Network Router                                        | ❌      | ✅          | ❌                      | ❌            | ❌             | ❌      | ❌      |
+| Operations                                                   | vSphere | oVirt / RHV | SCVMM | OpenStack undercloud    | IBM Power HMC | KubeVirt / OSV | Nutanix | Proxmox |
+| ------------------------------------------------------------ | ------- | ----------- | ----- | ----------------------- | --------------| -------------- | ------- | ------- |
+| VM Remote Console Access (see section below)                 | ✅      | ✅          | ✅    | ❌                      | ❌            | ✅             | ❌      | ❌      |
+| VM Power Operations                                          | ✅      | ✅          | ✅    | ❌                      | ✅            | ✅             | ✅      | ✅      |
+| VM Provisioning                                              |         |             |       |                         |               |                |         |
+|   &nbsp;&nbsp;&bull; using PXE                               | ✅      | ✅          | ❌    | ❌                      | ❌            | ❌             | ❌      | ❌      |
+|   &nbsp;&nbsp;&bull; using ISO                               | ❌      | ✅          | ❌    | ❌                      | ❌            | ❌             | ❌      | ❌      |
+|   &nbsp;&nbsp;&bull; from Template to VM                     | ✅      | ✅          | ✅    | ❌                      | ✅            | ✅             | ❌      | ❌      |
+|   &nbsp;&nbsp;&bull; from VM to Template                     | ✅      | ✅          | ❌    | ❌                      | ✅            | ❌             | ❌      | ❌      |
+|   &nbsp;&nbsp;&bull; Clone from VM to VM                     | ✅      | ❌          | ❌    | ❌                      | ❌            | ❌             | ❌      | ❌      |
+|   &nbsp;&nbsp;&bull; Sysprep Windows Templates               | ✅      | ✅          | ❌    | ❌                      | ❌            | ❌             | ❌      | ❌      |
+|   &nbsp;&nbsp;&bull; Cloud-init                              | ❌      | ✅          | ❌    | ❌                      | ❌            | ❌             | ❌      | ❌      |
+| VM Retirement                                                | ✅      | ✅          | ✅    | ❌                      | ✅            | ✅             | ✅      | ✅      |
+| VM Reconfiguration                                           | ✅      | ✅          | ❌    | ❌                      | ❌            | ✅ *           | ❌      | ❌      |
+|   &nbsp;&nbsp;&bull; Disk Addition                           | ✅      | ✅          | ❌    | ❌                      | ❌            | ❌             | ❌      | ❌      |
+|   &nbsp;&nbsp;&bull; Network Interface Add/Remove            | ✅      | ✅          | ❌    | ❌                      | ❌            | ❌             | ❌      | ❌      |
+| VM Snapshot Creation and Removal                             | ✅      | ✅          | ❌    | ❌                      | ❌            | ❌             | ❌      | ❌      |
+| Host Power Operations                                        | ✅      | ❌          | ❌    | ✅                      | ✅            | ❌             | ❌      | ❌      |
+| Node Operations                                              |         |             |       |                         |               | ❌             | ❌      | ❌      |
+|   &nbsp;&nbsp;&bull; Add/Remove Node                         | ❌      | ❌          | ❌    | ✅                      | ❌            | ❌             | ❌      | ❌      |
+|   &nbsp;&nbsp;&bull; Scale Down Node                         | ❌      | ❌          | ❌    | ✅ (Compute nodes only) | ❌            | ❌             | ❌      | ❌      |
+|   &nbsp;&nbsp;&bull; Scale Up Nodes                          | ❌      | ❌          | ❌    | ✅ (Compute nodes only) | ❌            | ❌             | ❌      | ❌      |
+|   &nbsp;&nbsp;&bull; Nodes Policy Enforcement                | ❌      | ❌          | ❌    | ✅                      | ❌            | ❌             | ❌      | ❌      |
+|   &nbsp;&nbsp;&bull; Nodes Evacuate                          | ❌      | ❌          | ❌    | ✅                      | ❌            | ❌             | ❌      | ❌      |
+| Create Cloud Network                                         | ❌      | ✅          | ❌    | ❌                      | ❌            | ❌             | ❌      | ❌      |
+| Delete Cloud Network                                         | ❌      | ✅          | ❌    | ❌                      | ❌            | ❌             | ❌      | ❌      |
+| Create Cloud Subnet                                          | ❌      | ✅          | ❌    | ❌                      | ❌            | ❌             | ❌      | ❌      |
+| Delete Cloud Subnet                                          | ❌      | ✅          | ❌    | ❌                      | ❌            | ❌             | ❌      | ❌      |
+| Create Network Router                                        | ❌      | ✅          | ❌    | ❌                      | ❌            | ❌             | ❌      | ❌      |
+| Delete Network Router                                        | ❌      | ✅          | ❌    | ❌                      | ❌            | ❌             | ❌      | ❌      |
 
 \* KubeVirt/OSV VMs created with an instance type are not supported for reconfigure
 


### PR DESCRIPTION
Ref: https://github.com/ManageIQ/manageiq/pull/23808

SCVMM was previously dropped by https://github.com/ManageIQ/manageiq-documentation/pull/1748
Update from that, we dropped SSA due to WMI compilation issues so I marked Forensic Analysis as `Forensic Analysis (SmartState)` though https://github.com/ManageIQ/manageiq-documentation/pull/1748 seems like it already had it marked as unsupported which might have just been a mistake.

Events and Metrics were also marked as supported which I think was a mistake by 69cc2f46bcf44c21e1f3df3618d0a92a671ab704
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
