### PR TITLE
Add OIDCPassClaimsAs default value to OIDC configuration docs

### DIFF
--- a/auth/openid_connect.md
+++ b/auth/openid_connect.md
@@ -141,6 +141,7 @@ The defaults in the *manageiq-external-auth-oidc.conf* file are:
 | LogLevel                 | warn      |
 | OIDCCryptoPassphrase     | sp-cookie |
 | OIDCOAuthRemoteUserClaim | username  |
+| OIDCPassClaimsAs         | both none |
 
 Installation specific values must be specified in the
 *manageiq-external-auth-oidc.conf* file for the following parameters,


### PR DESCRIPTION
mod_auth_openidc 2.4.15+ encodes claim values as ISO-8859-1 when passing them in headers/env vars. Characters outside the Latin-1 range cause an invalid byte sequence error. Setting OIDCPassClaimsAs to none disables this encoding for backwards compatibility.

Related: https://github.com/ManageIQ/manageiq-pods/pull/1406
https://github.com/ManageIQ/manageiq-appliance/pull/409
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
