### PR TITLE
Add a Credentials section to `manageiq://api`

### DIFF
--- a/managing_providers/_topics/embedded_workflows.md
+++ b/managing_providers/_topics/embedded_workflows.md
@@ -232,6 +232,10 @@ Workflows must be authored in Amazon State Languages (ASL) format. As part of au
     * `Options`
       * `Encoding` - Defaults to `JSON`
 
+    Credentials:
+    * `username`/`password` - If these are both present then a Basic Authorization header will be added
+    * `bearer_token` - If this is present then a Bearer Authorization header will be added.  The `bearer_token` Credential takes priority over `username`/`password`.
+
   * `manageiq://email` - Send an email using the configured SMTP server
 
     Parameters:


### PR DESCRIPTION
This documents that you can pass `username`/`password` or `bearer_token` in the `Credentials` section of the `manageiq://api` Task to simplify login to the manageiq api.

Added in https://github.com/ManageIQ/manageiq-providers-workflows/pull/159
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
