### PR TITLE
Replace Automation Manager strings with Automation Provider

### DIFF
--- a/api/reference/providers.md
+++ b/api/reference/providers.md
@@ -484,7 +484,7 @@ tags, policies and policy\_profiles subcollections will be rejected.
 
 Below you will find example requests for creating various providers.
 
-Ansible Automation Provider Automation Provider:
+Ansible Automation Provider:
 
 ``` json
 {

--- a/api/reference/providers.md
+++ b/api/reference/providers.md
@@ -484,7 +484,7 @@ tags, policies and policy\_profiles subcollections will be rejected.
 
 Below you will find example requests for creating various providers.
 
-Ansible Automation Provider Automation Manager:
+Ansible Automation Provider Automation Provider:
 
 ``` json
 {


### PR DESCRIPTION
Replace Automation Manager strings with Automation Provider

Relevant PRs:
- https://github.com/ManageIQ/manageiq/pull/23915
- https://github.com/ManageIQ/manageiq-content/pull/793
- https://github.com/ManageIQ/manageiq-ui-classic/pull/10162
- https://github.com/ManageIQ/manageiq-ui-service/pull/2110
- https://github.com/ManageIQ/manageiq-providers-awx/pull/65
- https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/344
- https://github.com/ManageIQ/manageiq-api-client/pull/165