### PR TITLE
Fix formatting of Unsupported ASL Features section

### DIFF
--- a/managing_providers/_topics/embedded_workflows.md
+++ b/managing_providers/_topics/embedded_workflows.md
@@ -165,15 +165,15 @@ Workflows must be authored in Amazon State Languages (ASL) format. As part of au
 
    The workflow code must be in the Amazon States Language (ASL) format and follow its supported specifications. For more information about Amazon States Language and its specification, see [Amazon States Language Guide](https://states-language.net/).
 
-   **Note**: The current implementation of the Amazon States Language does not support certain **Map** states. For more information, see [Unsupported Amazon States Language features](#unsupported-states-language-features).
+   * Unsupported Amazon States Language features
 
-   #### Unsupported Amazon States Language features
+     The current implementation of the Amazon States Language does not support certain features.
+      - Map State Fields:
+        - ItemReader
+        - ResultWriter
+       - JSONata expressions
 
-    The following features of Amazon States Language are not supported by Floe:
-    - Map State Fields:
-      - ItemReader
-      - ResultWriter
-    - JSONata expressions
+      For more information, see [Unsupported Amazon States Language features](#unsupported-states-language-features).
 
 * Build the docker containers that are required for the workflow.
 


### PR DESCRIPTION
The `####` wasn't properly aligned causing broken markdown to be rendered, and it didn't make sense as a top-level section in the context around it.


Before:
<img width="860" height="360" alt="Screenshot From 2026-07-13 12-01-29" src="https://github.com/user-attachments/assets/d730481b-1586-4ad3-996e-ea5d91b1dfc0" />

After:
<img width="821" height="288" alt="image" src="https://github.com/user-attachments/assets/cb50ea08-1827-41a9-a66f-d5c4ff233f5b" />
