### PR TITLE
Update configuration to clarify Kafka Cluster/Broker

### DIFF
--- a/_includes/configuration.md
+++ b/_includes/configuration.md
@@ -37,10 +37,10 @@ Configure the appliance by using the internal appliance console.
 
 Configuring messaging is required for the appliance setup. It is recommended to configure the broker on the same appliance where your database is configured
 
-**Note:** You can only have one Kafka broker per region.
+**Note:** You can only have one Kafka cluster per region. You can configure a Kafka high-availability cluster with multiple brokers for improved reliability and fault tolerance.
 
 1. You can either configure the current appliance as a Kafka broker, or point the
-   appliance to an existing external Kafka broker.
+   appliance to an existing external Kafka cluster.
 
    Select the appropriate option either
    **Configure this appliance as a messaging server** or
@@ -95,9 +95,9 @@ has a region configured with a database and messaging.
 
 12. Confirm the configuration if prompted.
 
-13. Choose **Connect to an external messaging system** to connect to the external kafka broker located on the appliance with the external database
+13. Choose **Connect to an external messaging system** to connect to the external kafka cluster located on the appliance with the external database
 
-    **Note:** You can only have one kafka broker per region
+    **Note:** All worker appliances in a region must use the same kafka cluster.
 
 14. Enter the necessary **Message Client Parameters** such as the hostname/IP and username/password
 


### PR DESCRIPTION
Update the configuration documentation to clarify that we require one kafka _cluster_ per region, not one broker.

I still need to update appliance_console to accept multiple hosts but for now this at least makes it clear that we need 1 cluster per region, not 1 broker per region.

Ref: https://github.com/orgs/ManageIQ/discussions/23924
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
