### PR TITLE
Fix KubeVirt/OSV VM Console Type

### DIFF
--- a/capabilities_matrix/_topics/infrastructure_providers.md
+++ b/capabilities_matrix/_topics/infrastructure_providers.md
@@ -77,5 +77,5 @@
 |              | WebMKS          |
 | RHV          | SPICE           |
 | SCVMM        | N/A             |
-| KubeVirt     | SPICE           |
-| OSV          | SPICE           |
+| KubeVirt     | VNC             |
+| OSV          | VNC             |


### PR DESCRIPTION
Previously we had a SPICE console option but this was dropped as it was no longer supported https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/272 and I forgot to remove it from the capabilities matrix here.

Now @ishaaq-48  has implemented VNC console so we have to update the console type in the list here.

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/23944
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/10204
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
